### PR TITLE
Step 3: word types (bomb/bonus/twin/decoy) + boss waves every 5 levels

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,7 +1,6 @@
-/* Word Fall — Neon Keys (Step 2)
-   Multi-word lock-on, combos, power-ups, particle FX, procedural audio.
-   Visual layer integrates skyline / typewriter cannon / sprite particles
-   / canvas HUD. Mechanics unchanged from Step 1. */
+/* Word Fall — Step 3
+   Adds word types (normal / bomb / bonus / twin / decoy / boss) + boss waves
+   every 5th level. Visual identity from Steps 1 & 2 preserved. */
 
 (() => {
 'use strict';
@@ -26,11 +25,34 @@ function poolForLevel(level) {
     return tiers.flat();
 }
 
+// ---------- Boss vocabulary (10–15 letters) ----------
+const BOSS_WORDS = [
+    'annihilation','obliteration','indestructible','electromagnetic','abomination',
+    'deconstruct','kaleidoscope','thunderstorm','choreography','constellation',
+    'metamorphosis','reverberation','incandescent','juxtaposition','perpendicular',
+    'quicksilver','unfathomable','encyclopedia','hemisphere','catastrophe',
+    'devastation','magnificent','microscopic','transcendent','phenomenal',
+    'revolution','domination','deliverance','masterpiece','turbulence',
+    'mischievous','paranormal','motivation','innovation',
+];
+
+// ---------- Word type spawn weights by level ----------
+function typeWeightsForLevel(level) {
+    if (level <= 2)  return { normal: 1.00 };
+    if (level <= 4)  return { normal: 0.90, bonus: 0.10 };
+    if (level <= 7)  return { normal: 0.75, bonus: 0.10, bomb: 0.10, decoy: 0.05 };
+    if (level <= 10) return { normal: 0.60, bonus: 0.10, bomb: 0.15, twin: 0.10, decoy: 0.05 };
+    return              { normal: 0.50, bonus: 0.10, bomb: 0.20, twin: 0.15, decoy: 0.05 };
+}
+
+function isBossLevel(level) { return level > 0 && level % 5 === 0; }
+
 // ---------- Asset preloader ----------
 const Assets = {
     logo: null, bgSkyline: null, cannon: null,
     sparkCyan: null, sparkMagenta: null,
     iconFreeze: null, iconBomb: null, iconShield: null,
+    chainLink: null, bossWarning: null, shardNeon: null,
 };
 const ASSET_MANIFEST = {
     logo:         'assets/img/logo-wordmark.png',
@@ -41,6 +63,9 @@ const ASSET_MANIFEST = {
     iconFreeze:   'assets/icons/icon-freeze.png',
     iconBomb:     'assets/icons/icon-bomb.png',
     iconShield:   'assets/icons/icon-shield.png',
+    chainLink:    'assets/vfx/chain-link.png',
+    bossWarning:  'assets/img/boss-warning.png',
+    shardNeon:    'assets/vfx/shard-neon.png',
 };
 const PU_ICON = { freeze: 'iconFreeze', bomb: 'iconBomb', shield: 'iconShield' };
 
@@ -72,22 +97,24 @@ const Audio = (() => {
         master.gain.value = 0.35;
         master.connect(ctx.destination);
     }
-    function tone(freq, dur, type = 'sine', vol = 0.3, sweepTo = null) {
+    function tone(freq, dur, type = 'sine', vol = 0.3, sweepTo = null, startOfs = 0) {
         if (muted) return; ensure(); if (!ctx) return;
+        const t0 = ctx.currentTime + startOfs;
         const o = ctx.createOscillator();
         const g = ctx.createGain();
         o.type = type;
-        o.frequency.value = freq;
-        if (sweepTo != null) o.frequency.exponentialRampToValueAtTime(sweepTo, ctx.currentTime + dur);
-        g.gain.value = 0.0001;
-        g.gain.exponentialRampToValueAtTime(vol, ctx.currentTime + 0.005);
-        g.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + dur);
+        o.frequency.setValueAtTime(freq, t0);
+        if (sweepTo != null) o.frequency.exponentialRampToValueAtTime(sweepTo, t0 + dur);
+        g.gain.setValueAtTime(0.0001, t0);
+        g.gain.exponentialRampToValueAtTime(vol, t0 + 0.005);
+        g.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
         o.connect(g).connect(master);
-        o.start(); o.stop(ctx.currentTime + dur + 0.02);
+        o.start(t0); o.stop(t0 + dur + 0.02);
     }
-    function noise(dur, vol = 0.3, lp = 1000) {
+    function noise(dur, vol = 0.3, lp = 1000, startOfs = 0) {
         if (muted) return; ensure(); if (!ctx) return;
-        const buf = ctx.createBuffer(1, ctx.sampleRate * dur, ctx.sampleRate);
+        const t0 = ctx.currentTime + startOfs;
+        const buf = ctx.createBuffer(1, Math.max(1, Math.floor(ctx.sampleRate * dur)), ctx.sampleRate);
         const data = buf.getChannelData(0);
         for (let i = 0; i < data.length; i++) data[i] = (Math.random() * 2 - 1);
         const src = ctx.createBufferSource();
@@ -95,10 +122,10 @@ const Audio = (() => {
         const filt = ctx.createBiquadFilter();
         filt.type = 'lowpass'; filt.frequency.value = lp;
         const g = ctx.createGain();
-        g.gain.value = vol;
-        g.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + dur);
+        g.gain.setValueAtTime(vol, t0);
+        g.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
         src.connect(filt).connect(g).connect(master);
-        src.start(); src.stop(ctx.currentTime + dur);
+        src.start(t0); src.stop(t0 + dur);
     }
     return {
         resume() { ensure(); if (ctx && ctx.state === 'suspended') ctx.resume(); },
@@ -123,17 +150,58 @@ const Audio = (() => {
             else if (type === 'shield') { tone(440, 0.15, 'sine', 0.2); tone(660, 0.2, 'sine', 0.2); }
         },
         lockOn() { tone(880, 0.04, 'square', 0.12); },
+        // --- Step 3 additions ---
+        bombHit() {
+            // Deeper / more aggressive than wordComplete
+            tone(180, 0.22, 'sawtooth', 0.32, 70);
+            tone(360, 0.18, 'square',   0.18, 120);
+            noise(0.12, 0.22, 1200);
+        },
+        bombDetonate() {
+            tone(80, 0.7, 'sawtooth', 0.45, 30);
+            noise(0.65, 0.5, 2200);
+            setTimeout(() => tone(50, 0.5, 'sawtooth', 0.3, 25), 80);
+        },
+        bonusComplete() {
+            const seq = [880, 1175, 1568, 1976, 2349];
+            seq.forEach((f, i) => setTimeout(() => tone(f, 0.10, 'sine', 0.22), i * 55));
+        },
+        twinFreeze() {
+            tone(660, 0.18, 'sine', 0.22, 440);
+            setTimeout(() => tone(440, 0.25, 'sine', 0.18, 330), 100);
+            setTimeout(() => tone(330, 0.32, 'sine', 0.14, 220), 220);
+        },
+        bossWarning() {
+            // 2-second descending warning tone
+            tone(440, 0.45, 'sawtooth', 0.32, 110, 0.00);
+            tone(330, 0.45, 'sawtooth', 0.32, 90,  0.50);
+            tone(220, 0.45, 'sawtooth', 0.32, 70,  1.00);
+            tone(165, 0.55, 'sawtooth', 0.34, 60,  1.50);
+            noise(2.0, 0.10, 800);
+        },
+        bossLetterShatter() {
+            noise(0.18, 0.28, 6000);
+            tone(1800, 0.08, 'square', 0.12, 900);
+            tone(2400, 0.06, 'square', 0.10, 1400);
+        },
+        bossDefeated() {
+            const seq = [392, 494, 587, 740, 988, 1175, 1568];
+            seq.forEach((f, i) => setTimeout(() => tone(f, 0.14, 'triangle', 0.3, f * 1.5), i * 70));
+            setTimeout(() => tone(1976, 0.45, 'triangle', 0.32, 2640), seq.length * 70);
+            noise(0.5, 0.18, 2500);
+        },
     };
 })();
 
 // ---------- Game state ----------
 const TOP_HUD_H = 60;
 const BOTTOM_HUD_H = 90;
-const FLOOR_OFFSET_FROM_BOTTOM = 60; // unchanged: missWord triggers at h - 60
+const FLOOR_OFFSET_FROM_BOTTOM = 60;
+const TWIN_CHAIN_MS = 2000;
 
 const game = {
     mode: 'classic',
-    state: 'loading',  // loading | menu | playing | paused | gameover
+    state: 'loading',  // loading | menu | playing | paused | gameover | detonated
     canvas: null, ctx: null,
     w: 0, h: 0, dpr: 1,
     words: [],
@@ -155,11 +223,17 @@ const game = {
     bgStars: [],
     cursorX: 0, cursorY: 0,
     high: null,
-    fireT: 0,                          // cannon fire-punch timer (ms remaining)
-    heartFx: [],                        // {idx, life} for heart-loss flash
-    loadT: 0,                          // loading screen anim time
-    powerupRects: [],                  // current draw rects for click hit-testing
+    fireT: 0,
+    heartFx: [],
+    loadT: 0,
+    powerupRects: [],
     showHint: true,
+    // Boss state
+    bossState: 'none',  // none | warning | fighting
+    bossWarnT: 0,
+    bossActive: null,   // ref to the boss word in game.words
+    detonateT: 0,       // ms countdown for DETONATED overlay
+    bossDefeatedAtLevels: new Set(),
 };
 
 // ---------- Persistence ----------
@@ -188,7 +262,6 @@ function init() {
     document.addEventListener('mousemove', e => { game.cursorX = e.clientX; game.cursorY = e.clientY; });
     game.canvas.addEventListener('click', onCanvasClick);
 
-    // Mode buttons
     document.querySelectorAll('#mode-select .mode').forEach(el => {
         el.addEventListener('click', () => {
             document.querySelectorAll('#mode-select .mode').forEach(m => m.classList.remove('selected'));
@@ -200,12 +273,8 @@ function init() {
     document.getElementById('again-btn').addEventListener('click', startGame);
     document.getElementById('menu-btn').addEventListener('click', toMenu);
 
-    // Begin render loop in 'loading' state, then preload, then go to menu.
     requestAnimationFrame(loop);
-    preloadAssets(() => {
-        applyLogoAssets();
-        game.state = 'menu';
-    });
+    preloadAssets(() => { applyLogoAssets(); game.state = 'menu'; });
 }
 
 function applyLogoAssets() {
@@ -230,7 +299,6 @@ function resize() {
 }
 
 function seedStars() {
-    // Reduced density (per spec: half) — these are foreground sparkle now.
     game.bgStars = [];
     const count = 70;
     for (let i = 0; i < count; i++) {
@@ -260,6 +328,11 @@ function startGame() {
     game.heartFx = [];
     game.fireT = 0;
     game.showHint = false;
+    game.bossState = 'none';
+    game.bossWarnT = 0;
+    game.bossActive = null;
+    game.detonateT = 0;
+    game.bossDefeatedAtLevels = new Set();
 
     if (game.mode === 'hardcore') { game.lives = 1; game.spawnInterval = 1200; }
     else if (game.mode === 'sprint') { game.lives = 3; game.spawnInterval = 1500; }
@@ -292,7 +365,7 @@ function gameOver(reason) {
     document.getElementById('go-title').textContent = reason || (game.mode === 'sprint' ? "TIME'S UP!" : 'GAME OVER');
     document.getElementById('go-sub').textContent = game.mode === 'sprint'
         ? 'You raced the clock.'
-        : 'Words crashed through your defense.';
+        : (reason === 'DETONATED' ? 'A bomb word slipped past you.' : 'Words crashed through your defense.');
     document.getElementById('go-score').textContent = game.score;
     document.getElementById('go-wpm').textContent = wpm;
     document.getElementById('go-combo').textContent = game.bestCombo;
@@ -300,36 +373,241 @@ function gameOver(reason) {
     setTimeout(() => show('gameover'), 1100);
 }
 
+function detonationGameOver() {
+    // Phase 1: DETONATED overlay for 1s; phase 2: standard game over.
+    game.state = 'detonated';
+    game.detonateT = 1000;
+    game.shake = 40;
+    game.flash = 0.85; game.flashColor = '#FF1744';
+    Audio.bombDetonate();
+}
+
 // ---------- Spawning ----------
+function recentWordTexts() { return new Set(game.words.map(w => w.text)); }
+
 function pickWord() {
     const pool = poolForLevel(game.level);
     const used = new Set(game.words.map(w => w.text[0]));
-    const sameTextSet = new Set(game.words.map(w => w.text));
-    let candidates = pool.filter(w => !used.has(w[0]) && !sameTextSet.has(w));
-    if (candidates.length === 0) candidates = pool.filter(w => !sameTextSet.has(w));
+    const same = recentWordTexts();
+    let candidates = pool.filter(w => !used.has(w[0]) && !same.has(w));
+    if (candidates.length === 0) candidates = pool.filter(w => !same.has(w));
     if (candidates.length === 0) candidates = pool;
     return candidates[(Math.random() * candidates.length) | 0];
 }
 
-function spawnWord() {
-    const text = pickWord();
-    const fontSize = Math.round(Math.max(18, Math.min(34, 30 - text.length * 0.4)) * 1.3);
-    game.ctx.font = `400 ${fontSize}px 'VT323', monospace`;
-    const tw = game.ctx.measureText(text).width;
-    const pad = 60;
-    const baseSpeed = 0.020 + (game.level - 1) * 0.0045;
+function pickTwoDistinctWords() {
+    const pool = poolForLevel(game.level);
+    const same = recentWordTexts();
+    const used = new Set(game.words.map(w => w.text[0]));
+    let a = pickWord();
+    let b = null;
+    for (let i = 0; i < 20 && !b; i++) {
+        const cand = pool[(Math.random() * pool.length) | 0];
+        if (cand !== a && !same.has(cand) && cand[0] !== a[0] && !used.has(cand[0])) b = cand;
+    }
+    if (!b) b = pool.find(w => w !== a && w[0] !== a[0]) || pool[0];
+    return [a, b];
+}
+
+function pickWordType(level) {
+    // Apply on-screen caps that the spec calls out.
+    const weights = { ...typeWeightsForLevel(level) };
+    const bombsOnScreen = game.words.filter(w => w.type === 'bomb').length;
+    if (bombsOnScreen >= 2) delete weights.bomb;
+    const twinPairOnScreen = game.words.some(w => w.type === 'twin');
+    if (twinPairOnScreen) delete weights.twin;
+
+    const total = Object.values(weights).reduce((a, b) => a + b, 0);
+    if (total <= 0) return 'normal';
+    let r = Math.random() * total;
+    for (const k of Object.keys(weights)) {
+        r -= weights[k];
+        if (r <= 0) return k;
+    }
+    return 'normal';
+}
+
+function fontSizeForText(text, scale = 1) {
+    return Math.round(Math.max(18, Math.min(34, 30 - text.length * 0.4)) * 1.3 * scale);
+}
+
+function measureWordWidth(text, size) {
+    game.ctx.font = `400 ${size}px 'VT323', monospace`;
+    return game.ctx.measureText(text).width;
+}
+
+function baseFallSpeed() {
     const jitter = (Math.random() - 0.5) * 0.012;
-    game.words.push({
+    return 0.020 + (game.level - 1) * 0.0045 + jitter;
+}
+
+function spawnNormal() {
+    const text = pickWord();
+    addWord({ text, type: 'normal' });
+}
+
+function spawnBomb() {
+    const text = pickWord();
+    addWord({ text, type: 'bomb', sizeScale: 1.15 });
+}
+
+function spawnBonus() {
+    const text = pickWord();
+    addWord({ text, type: 'bonus', sparkleT: 0 });
+}
+
+function spawnDecoy() {
+    const text = pickWord();
+    addWord({ text, type: 'decoy', speedScale: 0.55 });
+}
+
+function spawnTwinPair() {
+    const [a, b] = pickTwoDistinctWords();
+    const speed = baseFallSpeed();
+    const sizeA = fontSizeForText(a);
+    const sizeB = fontSizeForText(b);
+    const wA = measureWordWidth(a, sizeA);
+    const wB = measureWordWidth(b, sizeB);
+    const pad = 60;
+    // Separate by 200–400 px, both fit in viewport.
+    const sep = 200 + Math.random() * 200;
+    const totalSpan = wA / 2 + sep + wB / 2;
+    const leftCenterMin = pad + wA / 2;
+    const rightCenterMax = game.w - pad - wB / 2;
+    const minLeftX = leftCenterMin;
+    const maxLeftX = rightCenterMax - sep;
+    const leftX = Math.max(minLeftX, Math.min(maxLeftX, minLeftX + Math.random() * Math.max(0, maxLeftX - minLeftX)));
+    const rightX = leftX + sep;
+    const twinA = {
+        text: a, typed: 0, x: leftX, y: -40, speed, size: sizeA, width: wA,
+        hue: 150, wiggle: Math.random() * Math.PI * 2, spawnAt: performance.now(),
+        type: 'twin', partner: null, frozen: false, chainTimer: 0,
+        completed: false,
+    };
+    const twinB = {
+        text: b, typed: 0, x: rightX, y: -40, speed, size: sizeB, width: wB,
+        hue: 150, wiggle: Math.random() * Math.PI * 2, spawnAt: performance.now(),
+        type: 'twin', partner: null, frozen: false, chainTimer: 0,
+        completed: false,
+    };
+    twinA.partner = twinB; twinB.partner = twinA;
+    game.words.push(twinA, twinB);
+}
+
+function addWord({ text, type, sizeScale = 1, speedScale = 1, sparkleT }) {
+    const size = fontSizeForText(text, sizeScale);
+    const width = measureWordWidth(text, size);
+    const pad = 60;
+    const speed = baseFallSpeed() * speedScale;
+    const w = {
         text, typed: 0,
-        x: pad + tw / 2 + Math.random() * (game.w - tw - pad * 2),
+        x: pad + width / 2 + Math.random() * (game.w - width - pad * 2),
         y: -40,
-        speed: baseSpeed + jitter,
-        size: fontSize,
-        width: tw,
+        speed, size, width,
         hue: 180 + Math.random() * 180,
         wiggle: Math.random() * Math.PI * 2,
         spawnAt: performance.now(),
+        type,
+    };
+    if (type === 'bonus') w.sparkleT = sparkleT || 0;
+    game.words.push(w);
+}
+
+function spawnByType(t) {
+    if (t === 'bomb')  return spawnBomb();
+    if (t === 'bonus') return spawnBonus();
+    if (t === 'twin')  return spawnTwinPair();
+    if (t === 'decoy') return spawnDecoy();
+    return spawnNormal();
+}
+
+// ---------- Boss ----------
+function startBossWarning() {
+    if (game.bossState !== 'none') return;
+    game.bossState = 'warning';
+    game.bossWarnT = 2000;
+    Audio.bossWarning();
+    game.shake = Math.max(game.shake, 12);
+    // Pause currently-falling words during warning.
+    for (const w of game.words) w.pausedByBoss = true;
+    // Drop any pending target.
+    game.target = null; game.input = ''; renderInput();
+}
+
+function spawnBoss() {
+    // Clear all non-boss words for a clean fight.
+    game.words = game.words.filter(w => w.type === 'boss');
+    const text = BOSS_WORDS[(Math.random() * BOSS_WORDS.length) | 0];
+    const sizeBase = fontSizeForText(text); // VT323 sized for length already
+    const size = Math.round(sizeBase * 2.5);
+    game.ctx.font = `400 ${size}px 'VT323', monospace`;
+    const totalWidth = game.ctx.measureText(text).width;
+    // Per-letter positions (so typed letters don't reflow remaining ones).
+    const letters = [];
+    let xCursor = 0;
+    for (const ch of text) {
+        const lw = game.ctx.measureText(ch).width;
+        letters.push({ ch, cx: xCursor + lw / 2, w: lw, alive: true, shatterT: 0 });
+        xCursor += lw;
+    }
+    const startX = game.w / 2 - totalWidth / 2;
+    const boss = {
+        text, typed: 0, x: game.w / 2, y: -100,
+        speed: baseFallSpeed() * 0.5,
+        size, width: totalWidth,
+        hue: 320,
+        wiggle: 0, spawnAt: performance.now(),
+        type: 'boss',
+        letters, startX,
+    };
+    game.words.push(boss);
+    game.bossActive = boss;
+    game.bossState = 'fighting';
+}
+
+function bossDefeated(boss) {
+    // Big celebration.
+    explodeAt(boss.x, boss.y, true, 200, 'mix');
+    game.flash = 0.6; game.flashColor = '#00FF9F';
+    game.shake = Math.max(game.shake, 25);
+    setTimeout(() => game.shake = Math.max(game.shake, 12), 200);
+    Audio.bossDefeated();
+    game.score += 1000;
+    game.floaters.push({
+        text: '+1000  BOSS DOWN', x: boss.x, y: boss.y, vy: -0.06,
+        life: 1400, max: 1400, color: '#00FF9F', size: 38,
     });
+    // Grant 2 random power-ups.
+    for (let i = 0; i < 2; i++) {
+        const kinds = ['freeze', 'bomb', 'shield'];
+        const pick = kinds[(Math.random() * kinds.length) | 0];
+        game.powerups[pick]++;
+    }
+    game.bossDefeatedAtLevels.add(game.level);
+    game.bossState = 'none';
+    game.bossActive = null;
+    game.target = null; game.input = ''; renderInput();
+    // Remove boss word
+    game.words = game.words.filter(w => w !== boss);
+}
+
+function bossEscaped(boss) {
+    // -2 lives, heavy red flash, scaled-up miss treatment.
+    game.combo = 0; game.multiplier = 1; game.comboTimer = 0;
+    const lossCount = Math.min(2, game.lives);
+    for (let i = 0; i < lossCount; i++) {
+        game.heartFx.push({ idx: game.lives - 1 - i, life: 500 });
+    }
+    game.lives -= 2;
+    game.shake = Math.max(game.shake, 28);
+    game.flash = 0.75; game.flashColor = '#FF1744';
+    Audio.miss();
+    setTimeout(() => Audio.miss(), 100);
+    game.words = game.words.filter(w => w !== boss);
+    game.bossActive = null;
+    game.bossState = 'none';
+    game.target = null; game.input = ''; renderInput();
+    if (game.lives <= 0) gameOver();
 }
 
 // ---------- Input ----------
@@ -352,8 +630,9 @@ function onKey(e) {
     if (e.key.length !== 1 || !/[a-zA-Z]/.test(e.key)) return;
     const ch = e.key.toLowerCase();
 
+    // Power-up hotkeys: only when no target and no candidate first-letter match.
     if (!game.target) {
-        const hasCandidate = game.words.some(wd => wd.text[0] === ch);
+        const hasCandidate = lockOnCandidates().some(wd => wd.text[0] === ch);
         if (!hasCandidate) {
             if (ch === 'f' && game.powerups.freeze > 0) { usePowerup('freeze'); return; }
             if (ch === 'b' && game.powerups.bomb   > 0) { usePowerup('bomb');   return; }
@@ -362,8 +641,9 @@ function onKey(e) {
     }
 
     if (!game.target) {
+        const candidates = lockOnCandidates();
         let best = null;
-        for (const w of game.words) {
+        for (const w of candidates) {
             if (w.text[0] === ch) {
                 if (!best || w.y > best.y) best = w;
             }
@@ -377,6 +657,13 @@ function onKey(e) {
             Audio.lockOn();
             Audio.keyHit(1 / best.text.length);
             renderInput();
+            // Twin lock-on triggers partner freeze.
+            if (best.type === 'twin' && best.partner && !best.partner.completed) {
+                best.partner.frozen = true;
+                best.chainTimer = TWIN_CHAIN_MS;
+                best.partner.chainTimer = TWIN_CHAIN_MS;
+                Audio.twinFreeze();
+            }
             if (best.typed === best.text.length) completeWord(best);
         } else {
             if (game.combo > 0) game.comboTimer = Math.max(0, game.comboTimer - 800);
@@ -389,14 +676,40 @@ function onKey(e) {
         game.target.typed++;
         game.input = game.target.text.slice(0, game.target.typed);
         game.charsTyped++;
-        spawnBullet(game.target);
-        Audio.keyHit(game.target.typed / game.target.text.length);
+        // For boss: shatter the letter at this position.
+        if (game.target.type === 'boss') {
+            const li = game.target.letters[game.target.typed - 1];
+            if (li) {
+                li.alive = false;
+                li.shatterT = 400;
+                spawnLetterShatter(letterScreenX(game.target, li), game.target.y);
+                Audio.bossLetterShatter();
+                // Per-letter score reward
+                game.score += Math.round(10 * 5 * game.multiplier);
+            }
+        } else {
+            spawnBullet(game.target);
+            Audio.keyHit(game.target.typed / game.target.text.length);
+        }
         renderInput();
         if (game.target.typed === game.target.text.length) completeWord(game.target);
     } else {
         if (game.combo > 2) game.combo = Math.max(0, game.combo - 1);
         game.shake = Math.max(game.shake, 4);
     }
+}
+
+function lockOnCandidates() {
+    // Decoys excluded; boss takes priority during fight; non-boss excluded during boss.
+    if (game.bossState === 'fighting' && game.bossActive) {
+        return [game.bossActive];
+    }
+    if (game.bossState === 'warning') return [];
+    return game.words.filter(w => w.type !== 'decoy' && w.type !== 'boss');
+}
+
+function letterScreenX(boss, letter) {
+    return boss.startX + letter.cx;
 }
 
 function renderInput() {
@@ -423,38 +736,110 @@ function onCanvasClick(e) {
 }
 
 // ---------- Word complete / miss ----------
+function typeMultiplier(t) {
+    if (t === 'bonus') return 3;
+    if (t === 'twin')  return 1.5;
+    if (t === 'bomb')  return 1;
+    return 1; // normal, boss (boss handled separately)
+}
+
 function completeWord(w) {
     const base = 10 * w.text.length;
-    const gained = Math.round(base * game.multiplier);
+    const typeMul = typeMultiplier(w.type);
+    let gained = Math.round(base * typeMul * game.multiplier);
+    if (w.type === 'bomb') gained += 50;
     game.score += gained;
     game.wordsCompleted++;
     game.combo++;
     if (game.combo > game.bestCombo) game.bestCombo = game.combo;
     game.multiplier = 1 + Math.min(game.combo, 50) * 0.1;
     game.comboTimer = 3200;
-    Audio.wordComplete(game.combo);
     game.fireT = 100;
 
-    game.floaters.push({
-        text: `+${gained}`, x: w.x, y: w.y, vy: -0.06, life: 1000, max: 1000,
-        color: game.combo >= 5 ? '#FF2E97' : '#00FF9F',
-        size: 24 + Math.min(game.combo, 10),
-    });
+    // Per-type audio + FX
+    if (w.type === 'boss') {
+        // Boss letters score is per-keystroke; final completion triggers defeat.
+        bossDefeated(w);
+        return;
+    } else if (w.type === 'bomb') {
+        Audio.bombHit();
+        game.flash = 0.35; game.flashColor = '#00FF9F';
+        explodeAt(w.x, w.y, true, 50, 'redmagenta');
+    } else if (w.type === 'bonus') {
+        Audio.bonusComplete();
+        explodeAt(w.x, w.y, true, 60, 'gold');
+        // Grant the power-up the player has fewest of.
+        const counts = game.powerups;
+        const kinds = ['freeze', 'bomb', 'shield'];
+        let minK = kinds[0];
+        for (const k of kinds) if (counts[k] < counts[minK]) minK = k;
+        game.powerups[minK]++;
+        showToast(`POWER-UP: ${minK.toUpperCase()}`, '#FFD93D');
+    } else if (w.type === 'twin') {
+        Audio.wordComplete(game.combo);
+        explodeAt(w.x, w.y, true, 32, 'green');
+        w.completed = true;
+        if (w.partner && w.partner.completed) {
+            // Pair bonus on second completion: +50% of combined reward.
+            const partnerBase = 10 * w.partner.text.length;
+            const combined = Math.round((base * 1.5 + partnerBase * 1.5) * game.multiplier);
+            const bonus = Math.round(combined * 0.5);
+            game.score += bonus;
+            game.floaters.push({
+                text: `+${bonus} PAIR`, x: w.x, y: w.y - 26, vy: -0.07,
+                life: 1200, max: 1200, color: '#00FF9F', size: 26,
+            });
+        } else if (w.partner && !w.partner.completed) {
+            // Partner becomes new auto-target, chain timer resets.
+            w.partner.frozen = false;
+            w.partner.chainTimer = TWIN_CHAIN_MS;
+            game.target = w.partner;
+            w.partner.typed = 0;
+            renderInput();
+            // Don't unset target — we just set it.
+            game.floaters.push({
+                text: `+${gained}`, x: w.x, y: w.y, vy: -0.06,
+                life: 1000, max: 1000, color: '#00FF9F', size: 24 + Math.min(game.combo, 10),
+            });
+            game.words = game.words.filter(x => x !== w);
+            comboMilestoneCheck();
+            levelUpCheck();
+            return; // skip default cleanup
+        }
+    } else {
+        Audio.wordComplete(game.combo);
+        explodeAt(w.x, w.y, true, 28, 'cyan');
+    }
 
+    if (w.type !== 'twin' || (w.partner && w.partner.completed)) {
+        game.floaters.push({
+            text: `+${gained}`,
+            x: w.x, y: w.y, vy: -0.06,
+            life: 1000, max: 1000,
+            color: game.combo >= 5 ? '#FF2E97' : (w.type === 'bonus' ? '#FFD93D' : '#00FF9F'),
+            size: 24 + Math.min(game.combo, 10),
+        });
+    }
+
+    comboMilestoneCheck();
+
+    game.words = game.words.filter(x => x !== w);
+    game.target = null; game.input = ''; renderInput();
+
+    levelUpCheck();
+}
+
+function comboMilestoneCheck() {
     if (game.combo > 0 && game.combo % 10 === 0) {
         const kinds = ['freeze', 'bomb', 'shield'];
         const kind = kinds[(game.combo / 10 - 1) % kinds.length];
         game.powerups[kind]++;
         showToast(`POWER-UP: ${kind.toUpperCase()}`, '#00F0FF');
-        // Burst at the cannon for milestone celebration.
         burstAtCannon(36, 'magenta');
     }
+}
 
-    explodeAt(w.x, w.y, true /*lockedDestroy*/);
-
-    game.words = game.words.filter(x => x !== w);
-    game.target = null; game.input = ''; renderInput();
-
+function levelUpCheck() {
     const targetLevel = 1 + Math.floor(game.wordsCompleted / 12);
     if (targetLevel > game.level) {
         game.level = targetLevel;
@@ -462,32 +847,75 @@ function completeWord(w) {
         showToast(`LEVEL ${game.level}`, '#FF2E97');
         game.spawnInterval = Math.max(550, game.spawnInterval - 130);
         game.flash = 0.4; game.flashColor = '#00F0FF';
+        // Boss every 5th level
+        if (isBossLevel(game.level) && !game.bossDefeatedAtLevels.has(game.level)) {
+            startBossWarning();
+        }
     }
 }
 
 function missWord(w) {
+    if (w.type === 'decoy') {
+        // No penalty; just disappears.
+        game.words = game.words.filter(x => x !== w);
+        return;
+    }
+    if (w.type === 'bomb') {
+        // Instant game over regardless of lives.
+        game.words = game.words.filter(x => x !== w);
+        if (game.target === w) { game.target = null; game.input = ''; renderInput(); }
+        explodeAt(w.x, game.h - FLOOR_OFFSET_FROM_BOTTOM, true, 90, 'redmagenta');
+        detonationGameOver();
+        return;
+    }
+    if (w.type === 'boss') {
+        bossEscaped(w);
+        return;
+    }
+    if (w.type === 'twin') {
+        // Pair crash if partner exists and isn't completed.
+        const partner = w.partner;
+        if (partner && !partner.completed && partner !== w) {
+            // Both crash, 1 life only.
+            applySingleLifeLoss('#FF1744');
+            explodeAt(w.x, w.y, false, 24, 'green');
+            explodeAt(partner.x, partner.y, false, 24, 'green');
+            game.words = game.words.filter(x => x !== w && x !== partner);
+            if (game.target === w || game.target === partner) {
+                game.target = null; game.input = ''; renderInput();
+            }
+            if (game.lives <= 0) gameOver();
+            return;
+        }
+        // Partner already completed — single miss
+    }
+    // Shield consumes the miss
     if (game.shield) {
         game.shield = false;
         showToast('SHIELD BROKE', '#FF8A00');
         game.flash = 0.5; game.flashColor = '#FF8A00';
         game.shake = Math.max(game.shake, 8);
-        explodeAt(w.x, w.y, false);
+        explodeAt(w.x, w.y, false, 24, 'cyan');
         game.words = game.words.filter(x => x !== w);
         if (game.target === w) { game.target = null; game.input = ''; renderInput(); }
         Audio.powerup('shield');
         return;
     }
+    applySingleLifeLoss('#FF1744');
+    explodeAt(w.x, w.y, false, 32, 'cyan');
+    game.words = game.words.filter(x => x !== w);
+    if (game.target === w) { game.target = null; game.input = ''; renderInput(); }
+    if (game.lives <= 0) gameOver();
+}
+
+function applySingleLifeLoss(flashColor) {
     const lostIdx = game.lives - 1;
     game.lives--;
     game.heartFx.push({ idx: lostIdx, life: 400 });
     game.combo = 0; game.multiplier = 1; game.comboTimer = 0;
     Audio.miss();
     game.shake = Math.max(game.shake, 18);
-    game.flash = 0.55; game.flashColor = '#FF1744';
-    explodeAt(w.x, w.y, false);
-    game.words = game.words.filter(x => x !== w);
-    if (game.target === w) { game.target = null; game.input = ''; renderInput(); }
-    if (game.lives <= 0) gameOver();
+    game.flash = 0.55; game.flashColor = flashColor;
 }
 
 // ---------- Power-ups ----------
@@ -502,13 +930,22 @@ function usePowerup(kind) {
         showToast('FREEZE', '#00F0FF');
         game.flash = 0.3; game.flashColor = '#00F0FF';
     } else if (kind === 'bomb') {
-        const reward = game.words.length;
-        for (const w of game.words) {
-            explodeAt(w.x, w.y, false);
+        const targets = game.words.filter(w => w.type !== 'boss');
+        const reward = targets.length;
+        for (const w of targets) {
+            explodeAt(w.x, w.y, false, 22, 'cyan');
             game.score += Math.round(5 * w.text.length * game.multiplier);
         }
-        game.words = [];
-        game.target = null; game.input = ''; renderInput();
+        game.words = game.words.filter(w => w.type === 'boss');
+        // If the bomb-power-up killed a twin's partner, clean other twin's chain state.
+        for (const w of game.words) {
+            if (w.type === 'twin' && (!w.partner || !game.words.includes(w.partner))) {
+                w.partner = null; w.frozen = false; w.chainTimer = 0;
+            }
+        }
+        if (game.target && !game.words.includes(game.target)) {
+            game.target = null; game.input = ''; renderInput();
+        }
         game.shake = Math.max(game.shake, 14);
         game.flash = 0.5; game.flashColor = '#FF2E97';
         showToast(`BOMB x${reward}`, '#FF2E97');
@@ -519,16 +956,24 @@ function usePowerup(kind) {
 }
 
 // ---------- FX ----------
-function explodeAt(x, y, lockedDestroy) {
-    // Spec: locked-word destruction → 80% cyan / 20% magenta.
-    //       general → 60% cyan / 40% magenta.
-    const count = 28;
-    const cyanShare = lockedDestroy ? 0.8 : 0.6;
+function pickSparkKind(palette) {
+    // palette: 'cyan' | 'green' | 'gold' | 'redmagenta' | 'mix' | 'magenta'
+    const r = Math.random();
+    if (palette === 'cyan')         return r < 0.8 ? 'cyan' : 'magenta';
+    if (palette === 'magenta')      return r < 0.85 ? 'magenta' : 'cyan';
+    if (palette === 'green')        return 'green';
+    if (palette === 'gold')         return 'gold';
+    if (palette === 'redmagenta')   return r < 0.5 ? 'red' : 'magenta';
+    if (palette === 'mix')          return r < 0.5 ? 'cyan' : 'magenta';
+    return r < 0.6 ? 'cyan' : 'magenta';
+}
+
+function explodeAt(x, y, _locked, count = 28, palette = 'mix') {
     for (let i = 0; i < count; i++) {
         const a = Math.random() * Math.PI * 2;
-        const s = 0.05 + Math.random() * 0.45;
+        const s = 0.05 + Math.random() * 0.5;
         game.particles.push({
-            kind: Math.random() < cyanShare ? 'cyan' : 'magenta',
+            kind: pickSparkKind(palette),
             x, y,
             vx: Math.cos(a) * s, vy: Math.sin(a) * s,
             life: 600 + Math.random() * 500,
@@ -542,7 +987,7 @@ function explodeAt(x, y, lockedDestroy) {
 
 function burstAtCannon(count, biasKind) {
     const cx = game.w / 2;
-    const cy = game.h - 90; // top of cannon area
+    const cy = game.h - 90;
     for (let i = 0; i < count; i++) {
         const a = -Math.PI / 2 + (Math.random() - 0.5) * Math.PI;
         const s = 0.15 + Math.random() * 0.35;
@@ -552,8 +997,7 @@ function burstAtCannon(count, biasKind) {
                 : (Math.random() < 0.85 ? 'cyan' : 'magenta'),
             x: cx + (Math.random() - 0.5) * 30,
             y: cy,
-            vx: Math.cos(a) * s,
-            vy: Math.sin(a) * s,
+            vx: Math.cos(a) * s, vy: Math.sin(a) * s,
             life: 700 + Math.random() * 400,
             max: 1100,
             size: 28 + Math.random() * 14,
@@ -563,11 +1007,44 @@ function burstAtCannon(count, biasKind) {
     }
 }
 
+function spawnLetterShatter(x, y) {
+    // Glass-shard particles for boss letter shatter.
+    for (let i = 0; i < 18; i++) {
+        const a = -Math.PI / 2 + (Math.random() - 0.5) * Math.PI * 1.4;
+        const s = 0.12 + Math.random() * 0.45;
+        game.particles.push({
+            kind: 'shard',
+            x, y,
+            vx: Math.cos(a) * s, vy: Math.sin(a) * s,
+            life: 600 + Math.random() * 400,
+            max: 1000,
+            size: 18 + Math.random() * 14,
+            rot: Math.random() * Math.PI * 2,
+            spin: (Math.random() - 0.5) * 0.03,
+        });
+    }
+}
+
 function spawnBullet(w) {
     game.bullets.push({
         x: game.w / 2, y: game.h - 90,
         tx: w.x, ty: w.y, target: w,
         life: 0, max: 180,
+    });
+}
+
+function emitBonusSparkle(w) {
+    const a = Math.random() * Math.PI * 2;
+    game.particles.push({
+        kind: 'gold',
+        x: w.x + Math.cos(a) * (w.width / 2 + 10),
+        y: w.y + Math.sin(a) * (w.size / 2 + 6),
+        vx: Math.cos(a) * 0.04,
+        vy: Math.sin(a) * 0.04 + 0.02,
+        life: 600, max: 700,
+        size: 12 + Math.random() * 6,
+        rot: Math.random() * Math.PI * 2,
+        spin: (Math.random() - 0.5) * 0.04,
     });
 }
 
@@ -609,9 +1086,16 @@ function loop(now) {
     if (game.state === 'loading') {
         game.loadT += dt;
         drawLoadingScreen();
+    } else if (game.state === 'detonated') {
+        // Hold DETONATED overlay for ~1s before standard game-over.
+        game.detonateT -= dt;
+        draw(dt);
+        drawDetonatedOverlay();
+        if (game.detonateT <= 0) gameOver('DETONATED');
     } else {
         if (game.state === 'playing') update(dt);
         draw(dt);
+        if (game.bossState === 'warning') drawBossWarningOverlay();
     }
     requestAnimationFrame(loop);
 }
@@ -628,18 +1112,80 @@ function update(dt) {
     if (game.freezeTimer > 0) { game.freezeTimer -= dt; ts = 0.25; }
     const sdt = dt * ts;
 
+    // Boss warning timer
+    if (game.bossState === 'warning') {
+        game.bossWarnT -= dt;
+        if (game.bossWarnT <= 0) spawnBoss();
+        // During warning: don't spawn; words bob in place.
+        for (const w of game.words) {
+            w.wiggle += dt * 0.005;
+        }
+        // Skip the rest of update (no spawn / no normal falling).
+        for (const b of game.bullets) {
+            b.life += dt;
+            const t = Math.min(1, b.life / 140);
+            b.x = lerp(game.w / 2, b.target ? b.target.x : b.tx, t);
+            b.y = lerp(game.h - 90, b.target ? b.target.y : b.ty, t);
+        }
+        game.bullets = game.bullets.filter(b => b.life < b.max);
+        updateParticles(dt);
+        updateFloaters(dt);
+        decayVisualState(dt);
+        return;
+    }
+
+    // Spawning
     game.spawnCooldown -= dt;
     const maxOnScreen = 4 + Math.min(6, Math.floor(game.level / 2));
-    if (game.spawnCooldown <= 0 && game.words.length < maxOnScreen) {
-        spawnWord();
+    const bossActive = game.bossState === 'fighting';
+    if (!bossActive && game.spawnCooldown <= 0 && game.words.length < maxOnScreen) {
+        const t = pickWordType(game.level);
+        spawnByType(t);
         game.spawnCooldown = game.spawnInterval * (0.7 + Math.random() * 0.6);
     }
 
     const floor = game.h - FLOOR_OFFSET_FROM_BOTTOM;
     for (const w of game.words) {
-        w.y += w.speed * sdt;
+        // Twin partner freeze, twin chain timer
+        if (w.type === 'twin' && w.chainTimer > 0) {
+            w.chainTimer -= dt;
+            if (w.chainTimer <= 0) {
+                // Active chain expired. If neither completed yet, both crash.
+                const partner = w.partner;
+                if (!w.completed && partner && !partner.completed) {
+                    // Pair crash, 1 life.
+                    applySingleLifeLoss('#FF1744');
+                    explodeAt(w.x, w.y, false, 24, 'green');
+                    explodeAt(partner.x, partner.y, false, 24, 'green');
+                    game.words = game.words.filter(x => x !== w && x !== partner);
+                    if (game.target === w || game.target === partner) {
+                        game.target = null; game.input = ''; renderInput();
+                    }
+                    if (game.lives <= 0) gameOver();
+                    return;
+                } else {
+                    w.frozen = false; // resume normal fall
+                }
+            }
+        }
+
+        // Falling — frozen words stay put; partner-frozen twins stay put
+        const blocked = w.frozen || w.pausedByBoss || (bossActive && w.type !== 'boss');
+        if (!blocked) {
+            w.y += w.speed * sdt;
+        }
         w.wiggle += sdt * 0.003;
-        if (w.y > floor) { missWord(w); return; }
+
+        // Bonus sparkle emission
+        if (w.type === 'bonus') {
+            w.sparkleT += dt;
+            if (w.sparkleT >= 100) { w.sparkleT = 0; emitBonusSparkle(w); }
+        }
+
+        if (w.y > floor) {
+            missWord(w);
+            return;
+        }
     }
 
     for (const b of game.bullets) {
@@ -650,20 +1196,8 @@ function update(dt) {
     }
     game.bullets = game.bullets.filter(b => b.life < b.max);
 
-    for (const p of game.particles) {
-        p.x += p.vx * dt;
-        p.y += p.vy * dt;
-        p.vy += 0.0002 * dt;
-        p.rot += p.spin * dt;
-        p.life -= dt;
-    }
-    game.particles = game.particles.filter(p => p.life > 0);
-
-    for (const f of game.floaters) {
-        f.y += f.vy * dt;
-        f.life -= dt;
-    }
-    game.floaters = game.floaters.filter(f => f.life > 0);
+    updateParticles(dt);
+    updateFloaters(dt);
 
     for (const fx of game.heartFx) fx.life -= dt;
     game.heartFx = game.heartFx.filter(fx => fx.life > 0);
@@ -675,6 +1209,29 @@ function update(dt) {
 
     if (game.fireT > 0) game.fireT = Math.max(0, game.fireT - dt);
 
+    decayVisualState(dt);
+}
+
+function updateParticles(dt) {
+    for (const p of game.particles) {
+        p.x += p.vx * dt;
+        p.y += p.vy * dt;
+        p.vy += 0.0002 * dt;
+        p.rot += p.spin * dt;
+        p.life -= dt;
+    }
+    game.particles = game.particles.filter(p => p.life > 0);
+}
+
+function updateFloaters(dt) {
+    for (const f of game.floaters) {
+        f.y += f.vy * dt;
+        f.life -= dt;
+    }
+    game.floaters = game.floaters.filter(f => f.life > 0);
+}
+
+function decayVisualState(dt) {
     game.shake = Math.max(0, game.shake - dt * 0.05);
     game.flash = Math.max(0, game.flash - dt * 0.003);
 }
@@ -696,11 +1253,8 @@ function drawLoadingScreen() {
     ctx.fillText('LOADING…', w / 2, h / 2 - 20);
     ctx.shadowBlur = 0;
 
-    // Animated dot row
-    const dots = 5;
-    const gap = 18;
+    const dots = 5, gap = 18, dotR = 5;
     const totalW = (dots - 1) * gap;
-    const dotR = 5;
     const baseX = w / 2 - totalW / 2;
     const baseY = h / 2 + 40;
     for (let i = 0; i < dots; i++) {
@@ -727,6 +1281,7 @@ function draw(dt) {
     }
 
     drawBackground(ctx, w, h, dt);
+    drawTwinChains(ctx);
     drawTargetingBeam(ctx, w, h);
     drawWords(ctx);
     drawBullets(ctx);
@@ -763,7 +1318,6 @@ function draw(dt) {
 
 function drawBackground(ctx, w, h, dt) {
     if (Assets.bgSkyline) {
-        // Cover (crop to fill, no stretch).
         const img = Assets.bgSkyline;
         const ir = img.width / img.height;
         const cr = w / h;
@@ -771,11 +1325,9 @@ function drawBackground(ctx, w, h, dt) {
         if (ir > cr) { dh = h; dw = h * ir; dx = (w - dw) / 2; dy = 0; }
         else         { dw = w; dh = w / ir; dx = 0; dy = (h - dh) / 2; }
         ctx.drawImage(img, dx, dy, dw, dh);
-        // Frosted glass dim overlay.
         ctx.fillStyle = 'rgba(10, 14, 26, 0.55)';
         ctx.fillRect(0, 0, w, h);
     } else {
-        // Fallback: deep gradient + subtle grid (faded).
         const grad = ctx.createRadialGradient(w / 2, h / 2, 0, w / 2, h / 2, Math.max(w, h) * 0.7);
         grad.addColorStop(0, '#1A1B3A');
         grad.addColorStop(1, '#0A0E1A');
@@ -790,7 +1342,6 @@ function drawBackground(ctx, w, h, dt) {
         ctx.stroke();
     }
 
-    // Foreground sparkle stars (low alpha).
     for (const s of game.bgStars) {
         s.y += 0.02 * s.z * dt * (game.freezeTimer > 0 ? 0.25 : 1);
         if (s.y > h) { s.y = -2; s.x = Math.random() * w; }
@@ -801,11 +1352,9 @@ function drawBackground(ctx, w, h, dt) {
     ctx.globalAlpha = 1;
 }
 
-// Cannon position helpers
 function cannonPos() { return { x: game.w / 2, y: game.h - 60 }; }
 function cannonFireScale() {
     if (game.fireT <= 0) return 1;
-    // 1.0 → 1.08 → 1.0 over 100ms
     const t = 1 - game.fireT / 100;
     const tri = t < 0.5 ? t / 0.5 : (1 - t) / 0.5;
     return 1 + 0.08 * tri;
@@ -816,7 +1365,6 @@ function drawCannon(ctx, w, h) {
     const fireBoost = game.fireT > 0 ? 0.35 : 0;
     const baseAlpha = 0.45 + fireBoost;
 
-    // Soft cyan halo
     const r = 120;
     const g = ctx.createRadialGradient(cx, cy, 0, cx, cy, r);
     g.addColorStop(0, `rgba(0, 240, 255, ${baseAlpha})`);
@@ -832,10 +1380,9 @@ function drawCannon(ctx, w, h) {
         const dw = targetW * scale;
         const dh = targetW * aspect * scale;
         const dx = cx - dw / 2;
-        const dy = h - 20 - dh; // base ~20px from bottom
+        const dy = h - 20 - dh;
         ctx.drawImage(img, dx, dy, dw, dh);
     } else {
-        // Fallback primitive base
         ctx.fillStyle = '#1A1B3A';
         ctx.strokeStyle = 'rgba(0, 240, 255, 0.6)';
         ctx.lineWidth = 2;
@@ -863,14 +1410,12 @@ function drawTargetingBeam(ctx, w, h) {
     ctx.lineWidth = 2;
     ctx.beginPath();
     ctx.moveTo(cx, cy - 10);
-    // Curve via midpoint with waver
     const mx = (cx + tx) / 2 + wave;
     const my = (cy + ty) / 2;
     ctx.quadraticCurveTo(mx, my, tx, ty);
     ctx.stroke();
     ctx.restore();
 
-    // Trailing sparks along the beam
     for (let i = 0; i < 4; i++) {
         const t = ((performance.now() / 400) + i * 0.25) % 1;
         const x = lerp(cx, tx, t) + Math.sin(performance.now() * 0.01 + i) * 2;
@@ -887,33 +1432,165 @@ function drawTargetingBeam(ctx, w, h) {
     ctx.shadowBlur = 0;
 }
 
-function drawWords(ctx) {
+function drawTwinChains(ctx) {
+    const seen = new Set();
     for (const w of game.words) {
-        const isTarget = (w === game.target);
+        if (w.type !== 'twin' || !w.partner || w.completed || w.partner.completed) continue;
+        if (seen.has(w.partner)) continue;
+        seen.add(w);
+        const p = w.partner;
+        const x1 = Math.min(w.x, p.x);
+        const x2 = Math.max(w.x, p.x);
+        const y1 = w.y;
+        const y2 = p.y;
+        const t = performance.now();
+        const wave = Math.sin(t * 0.005) * 3;
+        const midY = (y1 + y2) / 2 + wave;
+        if (Assets.chainLink) {
+            // Tile-stretch chain link texture between the two centers.
+            const img = Assets.chainLink;
+            const linkH = 22;
+            const len = Math.hypot(x2 - x1, y2 - y1);
+            const ang = Math.atan2(y2 - y1, x2 - x1);
+            ctx.save();
+            ctx.translate(x1, y1);
+            ctx.rotate(ang);
+            ctx.globalAlpha = 0.85;
+            // Tile the texture along the length
+            const tileW = (img.width / img.height) * linkH;
+            const tiles = Math.max(1, Math.ceil(len / tileW));
+            for (let i = 0; i < tiles; i++) {
+                ctx.drawImage(img, i * tileW, -linkH / 2, tileW + 1, linkH);
+            }
+            ctx.restore();
+            ctx.globalAlpha = 1;
+        } else {
+            // Dashed glowing line fallback
+            ctx.save();
+            ctx.strokeStyle = 'rgba(0, 255, 159, 0.6)';
+            ctx.lineWidth = 4;
+            ctx.setLineDash([10, 6]);
+            ctx.shadowColor = '#00FF9F';
+            ctx.shadowBlur = 12;
+            ctx.beginPath();
+            ctx.moveTo(x1, y1);
+            ctx.quadraticCurveTo((x1 + x2) / 2, midY, x2, y2);
+            ctx.stroke();
+            ctx.restore();
+        }
+    }
+}
+
+function drawWords(ctx) {
+    const t = performance.now();
+    for (const w of game.words) {
+        if (w.type === 'boss') { drawBossWord(ctx, w); continue; }
         const xOff = Math.sin(w.wiggle) * 2;
         const x = w.x + xOff;
         const y = w.y;
+        const isTarget = (w === game.target);
         const proximity = Math.min(1, w.y / (game.h - FLOOR_OFFSET_FROM_BOTTOM));
         const inDanger = (w.y / game.h) > 0.8;
 
         ctx.save();
-        ctx.font = `${w.size}px VT323, monospace`;
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
         ctx.lineJoin = 'round';
 
+        let fontSize = w.size;
+        if (w.type === 'bomb') {
+            // Pulse 1.0 → 1.08 → 1.0 on ~600ms cycle (spec: Math.sin(time / 100))
+            const pulse = 1.04 + 0.04 * Math.sin(t / 100);
+            fontSize = Math.round(w.size * pulse);
+        }
+        ctx.font = `${fontSize}px VT323, monospace`;
+
+        if (w.type === 'decoy') {
+            const alpha = 0.15 + 0.4 * (0.5 + 0.5 * Math.sin(t / 1500 * 2 * Math.PI));
+            ctx.globalAlpha = alpha;
+            drawWordSegment(ctx, w.text, x, y, 'rgba(107, 114, 153, 0.85)', null, 0, /*centered*/true);
+            ctx.globalAlpha = 1;
+            ctx.restore();
+            continue;
+        }
+
+        if (w.type === 'bonus') {
+            // Gentle oscillation -3° → +3° on 1200ms cycle
+            const ang = 3 * Math.PI / 180 * Math.sin(t / 1200 * 2 * Math.PI);
+            ctx.translate(x, y);
+            ctx.rotate(ang);
+            if (isTarget) {
+                const totalW = ctx.measureText(w.text).width;
+                const startX = -totalW / 2;
+                ctx.textAlign = 'left';
+                const typed = w.text.slice(0, w.typed);
+                const rest = w.text.slice(w.typed);
+                const typedW = ctx.measureText(typed).width;
+                drawWordSegment(ctx, typed, startX, 0, '#FFD93D', '#FFD93D', 16, false);
+                drawWordSegment(ctx, rest,  startX + typedW, 0, '#FFD93D', '#FFD93D', 12, false);
+            } else {
+                drawWordCentered(ctx, w.text, 0, 0, '#FFD93D', '#FFD93D', 14);
+            }
+            ctx.restore();
+            continue;
+        }
+
+        if (w.type === 'bomb') {
+            if (isTarget) {
+                const totalW = ctx.measureText(w.text).width;
+                const startX = x - totalW / 2;
+                ctx.textAlign = 'left';
+                const typed = w.text.slice(0, w.typed);
+                const rest = w.text.slice(w.typed);
+                const typedW = ctx.measureText(typed).width;
+                drawWordSegment(ctx, typed, startX, y, '#FFD93D', '#FFD93D', 12, false);
+                drawWordSegment(ctx, rest,  startX + typedW, y, '#FF1744', '#FF1744', 18, false);
+            } else if (inDanger) {
+                const pulse = 0.85 + 0.15 * (0.5 + 0.5 * Math.sin(t * 0.012));
+                ctx.globalAlpha = pulse;
+                drawWordCentered(ctx, w.text, x, y, '#FF1744', '#FF1744', 20);
+                ctx.globalAlpha = 1;
+            } else {
+                drawWordCentered(ctx, w.text, x, y, '#FF1744', '#FF1744', 14);
+            }
+            ctx.restore();
+            continue;
+        }
+
+        if (w.type === 'twin') {
+            const baseColor = w.frozen ? '#00FF9F' : '#00FF9F';
+            const baseGlow = w.frozen ? 20 : 12;
+            const pulse = w.frozen ? (0.85 + 0.15 * (0.5 + 0.5 * Math.sin(t * 0.012))) : 1;
+            ctx.globalAlpha = pulse;
+            if (isTarget) {
+                const totalW = ctx.measureText(w.text).width;
+                const startX = x - totalW / 2;
+                ctx.textAlign = 'left';
+                const typed = w.text.slice(0, w.typed);
+                const rest = w.text.slice(w.typed);
+                const typedW = ctx.measureText(typed).width;
+                drawWordSegment(ctx, typed, startX, y, '#FFD93D', '#FFD93D', 12, false);
+                drawWordSegment(ctx, rest,  startX + typedW, y, baseColor, baseColor, baseGlow + 4, false);
+            } else {
+                drawWordCentered(ctx, w.text, x, y, baseColor, baseColor, baseGlow);
+            }
+            ctx.globalAlpha = 1;
+            ctx.restore();
+            continue;
+        }
+
+        // Normal word
         if (isTarget) {
-            // Locked: draw typed prefix in gold + rest in cyan, each with full 3-pass.
             const totalW = ctx.measureText(w.text).width;
             const startX = x - totalW / 2;
             ctx.textAlign = 'left';
             const typed = w.text.slice(0, w.typed);
-            const rest  = w.text.slice(w.typed);
+            const rest = w.text.slice(w.typed);
             const typedW = ctx.measureText(typed).width;
-            drawWordSegment(ctx, typed, startX, y, '#FFD93D', '#FFD93D', 12);
-            drawWordSegment(ctx, rest,  startX + typedW, y, '#00F0FF', '#00F0FF', 16);
+            drawWordSegment(ctx, typed, startX, y, '#FFD93D', '#FFD93D', 12, false);
+            drawWordSegment(ctx, rest,  startX + typedW, y, '#00F0FF', '#00F0FF', 16, false);
         } else if (inDanger) {
-            const pulse = 0.85 + 0.15 * (0.5 + 0.5 * Math.sin(performance.now() * 0.012));
+            const pulse = 0.85 + 0.15 * (0.5 + 0.5 * Math.sin(t * 0.012));
             ctx.globalAlpha = pulse;
             drawWordCentered(ctx, w.text, x, y, '#FF8A00', '#FF8A00', 20);
             ctx.globalAlpha = 1;
@@ -924,10 +1601,26 @@ function drawWords(ctx) {
     }
 }
 
+function drawBossWord(ctx, boss) {
+    const t = performance.now();
+    ctx.save();
+    ctx.font = `${boss.size}px VT323, monospace`;
+    ctx.textBaseline = 'middle';
+    ctx.textAlign = 'left';
+    ctx.lineJoin = 'round';
+    const y = boss.y;
+    for (const li of boss.letters) {
+        if (!li.alive) continue;
+        const x = boss.startX + li.cx - li.w / 2;
+        // Heavy 3-pass with mega glow
+        drawWordSegment(ctx, li.ch, x, y, '#FF2E97', '#FF2E97', 30, false);
+    }
+    ctx.restore();
+}
+
 // 3-pass: dark plate (double draw), dark stroke outline, then colored fill.
-function drawWordSegment(ctx, str, x, y, fillColor, glowColor, glowBlur) {
+function drawWordSegment(ctx, str, x, y, fillColor, glowColor, glowBlur, _centered) {
     if (!str) return;
-    // Pass A: dark shadow plate
     ctx.save();
     ctx.shadowBlur = 24;
     ctx.shadowColor = '#0A0E1A';
@@ -936,13 +1629,11 @@ function drawWordSegment(ctx, str, x, y, fillColor, glowColor, glowBlur) {
     ctx.fillText(str, x, y);
     ctx.restore();
 
-    // Pass B: dark stroke outline
     ctx.strokeStyle = '#0A0E1A';
     ctx.lineWidth = 3;
     ctx.lineJoin = 'round';
     ctx.strokeText(str, x, y);
 
-    // Pass C: colored fill (with optional neon glow)
     if (glowColor) { ctx.shadowBlur = glowBlur; ctx.shadowColor = glowColor; }
     else           { ctx.shadowBlur = 0; }
     ctx.fillStyle = fillColor;
@@ -951,7 +1642,7 @@ function drawWordSegment(ctx, str, x, y, fillColor, glowColor, glowBlur) {
 }
 
 function drawWordCentered(ctx, str, x, y, fillColor, glowColor, glowBlur) {
-    drawWordSegment(ctx, str, x, y, fillColor, glowColor, glowBlur);
+    drawWordSegment(ctx, str, x, y, fillColor, glowColor, glowBlur, true);
 }
 
 function drawBullets(ctx) {
@@ -974,9 +1665,34 @@ function drawParticles(ctx) {
         const life01 = Math.max(0, p.life / p.max);
         const alpha = life01;
         const scale = 0.4 + life01 * 0.6;
-        const sprite = p.kind === 'magenta' ? Assets.sparkMagenta : Assets.sparkCyan;
         ctx.globalAlpha = alpha;
-        if (sprite) {
+        if (p.kind === 'shard' && Assets.shardNeon) {
+            const sz = p.size * scale;
+            ctx.save();
+            ctx.translate(p.x, p.y);
+            ctx.rotate(p.rot);
+            ctx.drawImage(Assets.shardNeon, -sz / 2, -sz / 2, sz, sz);
+            ctx.restore();
+            continue;
+        }
+        if (p.kind === 'shard') {
+            // canvas fallback for shard: thin triangle
+            ctx.save();
+            ctx.translate(p.x, p.y);
+            ctx.rotate(p.rot);
+            ctx.fillStyle = '#00F0FF';
+            ctx.shadowColor = '#00F0FF'; ctx.shadowBlur = 8;
+            ctx.beginPath();
+            ctx.moveTo(0, -p.size * 0.4 * scale);
+            ctx.lineTo(p.size * 0.2 * scale, p.size * 0.4 * scale);
+            ctx.lineTo(-p.size * 0.2 * scale, p.size * 0.4 * scale);
+            ctx.closePath();
+            ctx.fill();
+            ctx.restore();
+            continue;
+        }
+        const sprite = p.kind === 'magenta' ? Assets.sparkMagenta : Assets.sparkCyan;
+        if (sprite && (p.kind === 'cyan' || p.kind === 'magenta')) {
             const sz = p.size * scale;
             ctx.save();
             ctx.translate(p.x, p.y);
@@ -984,8 +1700,11 @@ function drawParticles(ctx) {
             ctx.drawImage(sprite, -sz / 2, -sz / 2, sz, sz);
             ctx.restore();
         } else {
-            // Fallback colored circle
-            ctx.fillStyle = p.kind === 'magenta' ? '#FF2E97' : '#00F0FF';
+            const col = ({
+                magenta: '#FF2E97', cyan: '#00F0FF',
+                gold: '#FFD93D', red: '#FF1744', green: '#00FF9F',
+            })[p.kind] || '#00F0FF';
+            ctx.fillStyle = col;
             ctx.fillRect(p.x - p.size * scale / 4, p.y - p.size * scale / 4, p.size * scale / 2, p.size * scale / 2);
         }
     }
@@ -996,7 +1715,6 @@ function drawFloaters(ctx) {
     for (const f of game.floaters) {
         const a = Math.min(1, f.life / 400);
         ctx.globalAlpha = a;
-        // Big juicy numbers → Monoton
         ctx.font = `400 ${Math.round(f.size * 1.1)}px 'Monoton', Impact, sans-serif`;
         ctx.textAlign = 'center';
         ctx.fillStyle = f.color;
@@ -1021,7 +1739,6 @@ function drawShieldAura(ctx, w, h) {
 
 // ---------- Canvas HUD ----------
 function drawTopHud(ctx, w, h) {
-    // Strip background
     ctx.fillStyle = 'rgba(10, 14, 26, 0.75)';
     ctx.fillRect(0, 0, w, TOP_HUD_H);
     ctx.strokeStyle = 'rgba(0, 240, 255, 0.4)';
@@ -1035,22 +1752,18 @@ function drawTopHud(ctx, w, h) {
 
     ctx.textBaseline = 'alphabetic';
 
-    // Score
     let x = padX, y = 22;
     ctx.font = labelFont; ctx.fillStyle = '#6B7299';
     ctx.textAlign = 'left'; ctx.fillText('SCORE', x, y);
     ctx.font = valueBigFont; ctx.fillStyle = '#F0F4FF';
-    ctx.shadowBlur = 0;
     ctx.fillText(String(game.score), x, y + 28);
 
-    // Level
     x = padX + 180;
     ctx.font = labelFont; ctx.fillStyle = '#6B7299';
     ctx.fillText('LEVEL', x, y);
     ctx.font = valueBigFont; ctx.fillStyle = '#F0F4FF';
     ctx.fillText(String(game.level), x, y + 28);
 
-    // Mode label (center)
     ctx.textAlign = 'center';
     ctx.font = labelFont; ctx.fillStyle = '#6B7299';
     ctx.fillText('MODE', w / 2, y);
@@ -1059,23 +1772,26 @@ function drawTopHud(ctx, w, h) {
     ctx.fillText(game.mode.toUpperCase(), w / 2, y + 24);
     ctx.shadowBlur = 0;
 
-    // WPM (right side, before hearts)
     ctx.textAlign = 'right';
-    const heartArea = drawHearts(ctx, w - padX, 30);
-    const wpmRight = w - padX - heartArea - 24;
+    // Right side: hearts OR boss progress bar
+    let rightConsumed = 0;
+    if (game.bossState === 'fighting' && game.bossActive) {
+        rightConsumed = drawBossProgressBar(ctx, w - padX, 14);
+    } else {
+        rightConsumed = drawHearts(ctx, w - padX, 30);
+    }
+    const wpmRight = w - padX - rightConsumed - 24;
     ctx.font = labelFont; ctx.fillStyle = '#6B7299';
     ctx.fillText('WPM', wpmRight, y);
     ctx.font = valueFont; ctx.fillStyle = '#F0F4FF';
     ctx.fillText(String(currentWPM()), wpmRight, y + 26);
 }
 
-// Returns total width consumed by hearts.
 function drawHearts(ctx, rightX, centerY) {
     const maxLives = game.mode === 'hardcore' ? 1 : (game.mode === 'sprint' ? 3 : 5);
-    const spacing = 24;
-    const heartSize = 16;
+    const spacing = 24, heartSize = 16;
     const totalW = (maxLives - 1) * spacing + heartSize;
-    const startX = rightX - totalW + heartSize / 2; // first heart center
+    const startX = rightX - totalW + heartSize / 2;
     for (let i = 0; i < maxLives; i++) {
         const cx = startX + i * spacing;
         const cy = centerY;
@@ -1083,7 +1799,6 @@ function drawHearts(ctx, rightX, centerY) {
         const fx = game.heartFx.find(h => h.idx === i);
         let scale = 1, color = '#FF2E97';
         if (fx) {
-            // 1.0 → 1.5 over first half, then back
             const t = 1 - fx.life / 400;
             scale = 1 + 0.5 * Math.sin(t * Math.PI);
             color = '#F0F4FF';
@@ -1094,10 +1809,7 @@ function drawHearts(ctx, rightX, centerY) {
         ctx.translate(cx, cy);
         ctx.scale(scale, scale);
         ctx.fillStyle = color;
-        if (!lost || fx) {
-            ctx.shadowColor = '#FF2E97';
-            ctx.shadowBlur = 8;
-        }
+        if (!lost || fx) { ctx.shadowColor = '#FF2E97'; ctx.shadowBlur = 8; }
         drawHeartPath(ctx, heartSize);
         ctx.fill();
         ctx.restore();
@@ -1106,7 +1818,6 @@ function drawHearts(ctx, rightX, centerY) {
 }
 
 function drawHeartPath(ctx, size) {
-    // Draw a filled heart centered at (0,0) sized to fit `size`
     const s = size / 16;
     ctx.beginPath();
     ctx.moveTo(0, 5 * s);
@@ -1119,6 +1830,36 @@ function drawHeartPath(ctx, size) {
     ctx.closePath();
 }
 
+function drawBossProgressBar(ctx, rightX, topY) {
+    const boss = game.bossActive;
+    const remaining = boss.text.length - boss.typed;
+    const barW = Math.round(game.w * 0.18);
+    const barH = 10;
+    const x = rightX - barW;
+    const y = topY;
+    // Frame
+    ctx.fillStyle = '#0A0E1A';
+    ctx.strokeStyle = '#FF2E97';
+    ctx.lineWidth = 1;
+    roundRect(ctx, x, y, barW, barH, 3);
+    ctx.fill();
+    ctx.stroke();
+    // Fill
+    const filled = boss.typed / boss.text.length;
+    if (filled > 0) {
+        ctx.fillStyle = '#00F0FF';
+        roundRect(ctx, x + 2, y + 2, (barW - 4) * filled, barH - 4, 2);
+        ctx.fill();
+    }
+    // Label below
+    ctx.font = "400 14px VT323, monospace";
+    ctx.fillStyle = '#F0F4FF';
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'top';
+    ctx.fillText(`BOSS: ${remaining} LETTERS LEFT`, rightX, y + barH + 4);
+    return barW;
+}
+
 function drawBottomHud(ctx, w, h) {
     const top = h - BOTTOM_HUD_H;
     ctx.fillStyle = 'rgba(10, 14, 26, 0.75)';
@@ -1127,10 +1868,7 @@ function drawBottomHud(ctx, w, h) {
     ctx.lineWidth = 1;
     ctx.beginPath(); ctx.moveTo(0, top + 0.5); ctx.lineTo(w, top + 0.5); ctx.stroke();
 
-    // Power-up slots (left)
     drawPowerupSlots(ctx, 24, top + 17, w);
-
-    // Combo bar + multiplier (right)
     drawComboReadout(ctx, w - 24, top + 22);
 }
 
@@ -1145,7 +1883,6 @@ function drawPowerupSlots(ctx, x0, y0, totalW) {
         const x = x0 + i * (sz + gap);
         const y = y0;
         const has = game.powerups[kind] > 0;
-        // Slot background
         ctx.save();
         ctx.fillStyle = 'rgba(255, 255, 255, 0.05)';
         ctx.strokeStyle = 'rgba(0, 240, 255, 0.3)';
@@ -1153,7 +1890,6 @@ function drawPowerupSlots(ctx, x0, y0, totalW) {
         roundRect(ctx, x, y, sz, sz, 8);
         ctx.fill();
         ctx.stroke();
-        // Pulsing glow when available
         if (has) {
             const pulse = 0.3 + 0.2 * (0.5 + 0.5 * Math.sin(t * 0.005));
             ctx.shadowColor = `rgba(0, 240, 255, ${pulse + 0.2})`;
@@ -1173,7 +1909,6 @@ function drawPowerupSlots(ctx, x0, y0, totalW) {
             ctx.drawImage(iconAsset, x + (sz - iSz) / 2, y + (sz - iSz) / 2, iSz, iSz);
             ctx.globalAlpha = 1;
         } else {
-            // Fallback: letter
             ctx.font = "400 26px 'Monoton', Impact, sans-serif";
             ctx.textAlign = 'center';
             ctx.textBaseline = 'middle';
@@ -1183,14 +1918,12 @@ function drawPowerupSlots(ctx, x0, y0, totalW) {
             ctx.shadowBlur = 0;
         }
 
-        // Hotkey label below
         ctx.font = '14px VT323, monospace';
         ctx.fillStyle = '#F0F4FF';
         ctx.textAlign = 'center';
         ctx.textBaseline = 'top';
         ctx.fillText(hotkeys[kind], x + sz / 2, y + sz + 2);
 
-        // Count badge
         if (game.powerups[kind] > 1) {
             ctx.font = "700 12px Inter, sans-serif";
             ctx.fillStyle = '#FFD93D';
@@ -1208,7 +1941,6 @@ function drawComboReadout(ctx, rightX, y0) {
     const fill = Math.max(0, Math.min(1, game.comboTimer / 3200));
     const x = rightX - barW;
 
-    // Combo number + label (right-aligned, big Monoton)
     ctx.textAlign = 'right';
     ctx.textBaseline = 'alphabetic';
     ctx.font = "400 11px Inter, sans-serif";
@@ -1226,7 +1958,6 @@ function drawComboReadout(ctx, rightX, y0) {
     ctx.fillText(`${game.multiplier.toFixed(1)}x`, rightX, y0 + 28);
     ctx.shadowBlur = 0;
 
-    // Combo bar
     ctx.fillStyle = 'rgba(255, 255, 255, 0.08)';
     roundRect(ctx, x, y0 + 38, barW, barH, 3);
     ctx.fill();
@@ -1250,6 +1981,70 @@ function drawSprintTimer(ctx, w) {
     ctx.shadowBlur = 18;
     ctx.fillText(`${t.toFixed(1)}s`, w / 2, TOP_HUD_H + 50);
     ctx.shadowBlur = 0;
+}
+
+function drawBossWarningOverlay() {
+    const ctx = game.ctx, w = game.w, h = game.h;
+    const t = performance.now();
+    // Red gradient backdrop (or use bossWarning asset if available)
+    ctx.save();
+    if (Assets.bossWarning) {
+        const img = Assets.bossWarning;
+        const targetH = Math.min(h * 0.45, 360);
+        const aspect = img.width / img.height;
+        const dh = targetH;
+        const dw = Math.min(w, targetH * aspect);
+        const dx = (w - dw) / 2;
+        const dy = (h - dh) / 2;
+        ctx.globalAlpha = 0.9;
+        ctx.drawImage(img, dx, dy, dw, dh);
+    } else {
+        const grad = ctx.createLinearGradient(0, h / 2 - 120, 0, h / 2 + 120);
+        grad.addColorStop(0, 'rgba(255, 23, 68, 0.0)');
+        grad.addColorStop(0.5, 'rgba(255, 23, 68, 0.45)');
+        grad.addColorStop(1, 'rgba(255, 23, 68, 0.0)');
+        ctx.fillStyle = grad;
+        ctx.fillRect(0, h / 2 - 120, w, 240);
+        // Horizontal hazard stripes
+        ctx.strokeStyle = 'rgba(255, 23, 68, 0.55)';
+        ctx.lineWidth = 12;
+        ctx.setLineDash([24, 24]);
+        ctx.lineDashOffset = -(t * 0.05) % 48;
+        ctx.beginPath();
+        ctx.moveTo(0, h / 2 - 80); ctx.lineTo(w, h / 2 - 80);
+        ctx.moveTo(0, h / 2 + 80); ctx.lineTo(w, h / 2 + 80);
+        ctx.stroke();
+        ctx.setLineDash([]);
+    }
+    ctx.globalAlpha = 1;
+
+    // BOSS INCOMING text
+    ctx.font = "400 64px 'Monoton', Impact, sans-serif";
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    const pulse = 0.85 + 0.15 * (0.5 + 0.5 * Math.sin(t * 0.012));
+    ctx.globalAlpha = pulse;
+    ctx.fillStyle = '#FF1744';
+    ctx.shadowColor = '#FF1744'; ctx.shadowBlur = 30;
+    ctx.fillText('BOSS INCOMING', w / 2, h / 2);
+    ctx.shadowBlur = 0;
+    ctx.globalAlpha = 1;
+    ctx.restore();
+}
+
+function drawDetonatedOverlay() {
+    const ctx = game.ctx, w = game.w, h = game.h;
+    ctx.save();
+    ctx.fillStyle = 'rgba(255, 23, 68, 0.45)';
+    ctx.fillRect(0, 0, w, h);
+    ctx.font = "400 96px 'Monoton', Impact, sans-serif";
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillStyle = '#FF1744';
+    ctx.shadowColor = '#FF1744'; ctx.shadowBlur = 40;
+    ctx.fillText('DETONATED', w / 2, h / 2);
+    ctx.shadowBlur = 0;
+    ctx.restore();
 }
 
 // ---------- Helpers ----------


### PR DESCRIPTION
## Summary

Step 3 of Word Fall: introduces a **word type system** (`normal` / `bomb` / `bonus` / `twin` / `decoy` / `boss`) with per-level spawn weights, and **boss waves every 5th level**. Visual identity from Steps 1 & 2 untouched. All Step 1/2 mechanics preserved.

### Word types

Each word now carries a `type` and renders / behaves differently:

| Type   | Color (text + glow) | Behavior |
|--------|---------------------|----------|
| normal | `#F0F4FF` / cyan target glow | Standard |
| bomb   | `#FF1744` / red, +15 % font, scale-pulse `1.0 → 1.08` via `Math.sin(t/100)` | **Floor hit → instant game over** with DETONATED overlay (1 s), heavy shake + red flash. Successful type: bigger burst, red+magenta mix, +50 flat bonus, green screen flash |
| bonus  | `#FFD93D` / gold, oscillates ±3° on 1200 ms | Emits 1 gold sparkle every 100 ms while alive. Worth **3× normal**. On complete: 60-particle gold burst, sparkle chime, **grants the power-up the player has fewest of** |
| twin   | `#00FF9F` / green, spawn as a pair 200–400 px apart | Chain rendered between centers (uses `Assets.chainLink` tile-stretched if available, else dashed glowing curve). Locking onto one **freezes the partner for 2 s** (echoing-pulse SFX). If first twin done in time → partner auto-targets, timer resets. **1.5× each + 50 % pair bonus** on second completion. Timer expires before both typed → both crash, 1 life lost |
| decoy  | faded slate, alpha pulses 0.15–0.55 over 1500 ms | **Cannot be locked**, falls slowly, 0 points, no life lost on floor hit |
| boss   | `#FF2E97` / heavy magenta glow (`shadowBlur 30`), 2.5× normal size, half normal speed | See boss section |

### Spawn-weight tiers

- **L1–2**: 100 % normal
- **L3–4**: 90 % normal, 10 % bonus
- **L5–7**: 75 % / 10 % bonus / 10 % bomb / 5 % decoy
- **L8–10**: 60 % / 10 % bonus / 15 % bomb / 10 % twin / 5 % decoy
- **L11+**: 50 % / 10 % bonus / 20 % bomb / 15 % twin / 5 % decoy

Caps: max 2 bombs on screen, only 1 twin pair on screen.

### Boss waves (every 5th level)

State machine: `none → warning (2 s) → fighting → none`.

- **Warning** — descending warning tone (4-step sawtooth), shake bump, all current words frozen with a slight bob, no new spawns, target dropped, "BOSS INCOMING" banner in Monoton 64 px `#FF1744` with heavy glow. If `Assets.bossWarning` loaded it's drawn behind; otherwise red gradient + animated hazard-stripe fallback.
- **Spawn** — clears non-boss words for a clean fight. Picks a 10–15 letter word from a curated `BOSS_WORDS` array of 34 entries (`ANNIHILATION`, `ELECTROMAGNETIC`, `INDESTRUCTIBLE`, `KALEIDOSCOPE`, `CONSTELLATION`, …). Per-letter positions are pre-laid out so removing typed letters doesn't reflow the rest.
- **Typing** — only the boss is lockable during fight. Each correct keystroke shatters the corresponding letter: `Assets.shardNeon` particles if available, otherwise canvas-drawn cyan shard triangles. Plays glass-break SFX (high-pass noise + bright square ping). Per-letter score = `10 × 5 × multiplier`.
- **Defeat** — 200-particle cyan+magenta burst at boss position, magenta+cyan mix, `+1000` bonus, **2 random power-ups granted**, green flash, triumphant ascending arpeggio. Resumes normal spawning.
- **Escape** — boss reaches floor → `-2` lives (scaled up normal life loss), double red flash, double miss SFX. If lives `< 2` → game over.

### HUD

During boss fight, hearts are replaced with a **thin progress bar** (cyan fill on dark navy, 1 px magenta border, `18 %` of canvas width) plus `BOSS: N LETTERS LEFT` in VT323 below.

### Scoring

- Base = `10 × text length`
- × type multiplier (`bonus 3`, `twin 1.5`, others `1`)
- × combo multiplier
- Bomb: `+50` flat after multiplier
- Twin pair bonus: `+50 %` of combined twin reward when second twin completes
- Boss: `+5 × normal` per letter + `+1000` on defeat

### New procedural SFX

`Audio.bombHit`, `Audio.bombDetonate`, `Audio.bonusComplete`, `Audio.twinFreeze`, `Audio.bossWarning` (2-second descending tone), `Audio.bossLetterShatter` (high-pass noise + bright pings), `Audio.bossDefeated` (7-note ascending arpeggio + final sustained chord). Zero audio files.

### Asset fallbacks (sanity-checked)

- `chainLink` missing → 4 px dashed glowing green line with sin-wave waver
- `bossWarning` missing → animated red hazard gradient + scrolling stripe pair
- `shardNeon` missing → small cyan triangle particles with glow

Game starts and plays correctly even if all three Step-3 assets are missing.

## Test plan

- [x] `node --check game.js` passes
- [x] Lock-on candidate list excludes `decoy` (verified in `lockOnCandidates`)
- [x] Lock-on candidate list excludes non-boss words during boss fight
- [x] Bomb on floor → `detonationGameOver()` (not `applySingleLifeLoss`)
- [x] Twin pair-crash path: `applySingleLifeLoss` called exactly once (not twice)
- [x] Boss defeat / escape both clean up `game.bossActive` and `game.target`
- [x] Power-up `bomb` doesn't kill the boss (filtered by `w.type !== 'boss'`)
- [x] No remaining references to deleted DOM HUD elements
- [ ] Reviewer: play through to L5 and verify the boss banner, boss spawn, per-letter shatter, defeat reward + 2 power-ups
- [ ] Reviewer: trigger a bomb floor crash (L5+) and confirm DETONATED → game over even with lives remaining
- [ ] Reviewer: trigger a twin pair, lock one, deliberately let the chain timer expire, confirm both crash with 1 life lost

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBNCPHB2pWrDyhQQX6i3db)_