### PR TITLE
Fix: stuck loading bar + unresponsive tutorial buttons

### DIFF
--- a/game.js
+++ b/game.js
@@ -245,29 +245,37 @@ const AudioManager = (() => {
             pools[name] = [];
             nextIdx[name] = 0;
             const src = SFX_MANIFEST[name];
-            // Load one instance to validate; clone twice more for pooling.
             const probe = new Audio();
             probe.preload = 'auto';
             probe.src = src;
-            const onResolve = () => bumpAsset();
-            const onFail = () => {
-                failed[name] = true;
-                console.warn('Word Fall: SFX failed to load', name, src);
+            let settled = false;
+            const settle = (ok) => {
+                if (settled) return;
+                settled = true;
+                if (ok) {
+                    pools[name].push(probe);
+                    for (let i = 1; i < 3; i++) {
+                        const c = new Audio();
+                        c.preload = 'auto';
+                        c.src = src;
+                        pools[name].push(c);
+                    }
+                } else {
+                    failed[name] = true;
+                    console.warn('Word Fall: SFX timed out / failed', name, src);
+                }
                 bumpAsset();
             };
-            probe.addEventListener('canplaythrough', () => {
-                pools[name].push(probe);
-                for (let i = 1; i < 3; i++) {
-                    const c = new Audio();
-                    c.preload = 'auto';
-                    c.src = src;
-                    pools[name].push(c);
-                }
-                onResolve();
-            }, { once: true });
-            probe.addEventListener('error', onFail, { once: true });
-            // Begin actual load
-            try { probe.load(); } catch (e) { onFail(); }
+            // Use loadeddata + canplay (more reliable than canplaythrough,
+            // which Chrome often won't fire before audio context unlocks).
+            probe.addEventListener('loadeddata', () => settle(true), { once: true });
+            probe.addEventListener('canplay',    () => settle(true), { once: true });
+            probe.addEventListener('error',      () => settle(false), { once: true });
+            // Safety: if neither fires within 2.5s, assume the file is
+            // reachable (browser is just being lazy) and move on. SFX still
+            // plays when needed; we just stop blocking the boot bar.
+            setTimeout(() => settle(true), 2500);
+            try { probe.load(); } catch (e) { settle(false); }
         });
         // Music element
         musicEl = new Audio();
@@ -275,13 +283,18 @@ const AudioManager = (() => {
         musicEl.loop = true;
         musicEl.src = MUSIC_PATH;
         musicEl.volume = musicVol;
-        musicEl.addEventListener('canplaythrough', () => bumpAsset(), { once: true });
-        musicEl.addEventListener('error', () => {
-            musicFailed = true;
-            console.warn('Word Fall: music failed to load', MUSIC_PATH);
+        let musicSettled = false;
+        const settleMusic = (ok) => {
+            if (musicSettled) return;
+            musicSettled = true;
+            if (!ok) { musicFailed = true; console.warn('Word Fall: music failed', MUSIC_PATH); }
             bumpAsset();
-        }, { once: true });
-        try { musicEl.load(); } catch (e) { musicFailed = true; bumpAsset(); }
+        };
+        musicEl.addEventListener('loadeddata', () => settleMusic(true), { once: true });
+        musicEl.addEventListener('canplay',    () => settleMusic(true), { once: true });
+        musicEl.addEventListener('error',      () => settleMusic(false), { once: true });
+        setTimeout(() => settleMusic(true), 3500);
+        try { musicEl.load(); } catch (e) { settleMusic(false); }
     }
 
     function bumpAsset() {
@@ -673,12 +686,10 @@ function init() {
             setTimeout(() => { if (bootBar) bootBar.classList.remove('show'); }, 300);
         },
     });
-    // Also hide boot bar after images settle if audio is silent / never reports
+    // Unconditional fallback: hide the boot bar after 4s no matter what.
     setTimeout(() => {
-        if (imgDone >= imgTotal && audioDone >= audioTotal) {
-            if (bootBar) bootBar.classList.remove('show');
-        }
-    }, 5000);
+        if (bootBar) bootBar.classList.remove('show');
+    }, 4000);
 }
 
 // Same as preloadAssets but reports per-asset progress.
@@ -3413,9 +3424,13 @@ const Tutorial = (() => {
     ];
 
     function open(onCompleteCb) {
-        onDone = onCompleteCb || null;
+        onDone = (typeof onCompleteCb === 'function') ? onCompleteCb : null;
         stepIdx = 0;
         renderStep();
+        // Hide the menu so its overlay can't intercept clicks meant for
+        // the tutorial buttons (same z-index + backdrop-filter quirk).
+        hide('menu');
+        hide('gameover');
         show('tutorial');
         cancelAnimationFrame(raf);
         const tick = (t) => {
@@ -3430,7 +3445,12 @@ const Tutorial = (() => {
         cancelAnimationFrame(raf); raf = 0;
         try { localStorage.setItem('wordfall_tutorial_completed', 'true'); } catch (e) {}
         const cb = onDone; onDone = null;
-        if (cb) cb(skipped);
+        if (cb) {
+            cb(skipped);
+        } else {
+            // No callback (manual How-to-play) → return to menu.
+            show('menu');
+        }
     }
     function next() {
         if (stepIdx < steps.length - 1) {

--- a/index.html
+++ b/index.html
@@ -793,6 +793,11 @@
             font-weight: 400;
         }
 
+        /* Tutorial overlay sits above other overlays (which use z-index: 20)
+           so its buttons cannot be intercepted by anything behind it. */
+        #tutorial { z-index: 26; }
+        #settings-modal, #confirm-reset, #daily-played, #stats-modal { z-index: 22; }
+
         /* Tutorial panel */
         .tutorial-panel {
             max-width: min(560px, 94vw);


### PR DESCRIPTION
## Summary

Fixes two regressions introduced by Step 5:

### 1. Loading bar gets stuck partway

**Cause**: I was listening for `canplaythrough` on the audio probe elements. Chrome (and Safari to a lesser extent) won't fire `canplaythrough` on `<audio>` elements before the user has interacted with the page — audio loading is suspended until autoplay restrictions clear. With no event firing, `loadedAssets` never reached `totalAssets`, so the boot bar froze at whatever fraction had loaded plus the (image) preload, and the only fallback (`onReady`) never fired either.

**Fix**:
- Switch the probe to listen for `loadeddata` + `canplay` (both fire earlier and work without an unlocked audio context).
- Add a per-asset 2.5 s settle timeout (3.5 s for music) — if neither fires, we treat the file as reachable and stop blocking the boot bar. The SFX still play whenever they actually finish loading; we just stop blocking the boot bar UX on them.
- Add an unconditional 4 s timeout in `init()` that hides the boot bar no matter what.

### 2. Tutorial Next / Skip buttons don't respond

**Cause**: `Tutorial.open()` showed the tutorial overlay but never hid the menu overlay underneath it. Both `<div class="overlay show">` elements have the same z-index (20), full-viewport `position: fixed`, and `backdrop-filter: blur(12px)`. Even though the tutorial renders on top visually (later DOM order wins ties), `backdrop-filter` creates its own stacking context in some browsers and the menu's centred `.panel` ends up intercepting clicks aimed at the tutorial's NEXT / SKIP buttons.

**Fix**:
- `Tutorial.open()` now calls `hide('menu')` and `hide('gameover')` first.
- `Tutorial.close()` calls `show('menu')` when there's no completion callback (manual "How to play" path) so the player returns to the menu cleanly after dismissing.
- Belt-and-suspenders CSS: explicit `#tutorial { z-index: 26; }` above all other overlays (settings/confirm/daily/stats at 22) so the boot progress bar (25) can't visually overlap it either.

## Test plan

- [x] `node --check game.js` passes
- [ ] Reviewer: hard-refresh — confirm the boot bar fills and disappears within ~4 s even on a cold cache, with no stuck partial state
- [ ] Reviewer: hit PLAY on a profile where the tutorial hasn't been completed — confirm the menu disappears behind the tutorial, NEXT advances through the four steps, SKIP dismisses immediately, and pressing "Start Playing" on step 4 launches the game
- [ ] Reviewer: open the HOW TO PLAY (?) icon from the menu — confirm the same flow, and that dismissing returns to the menu (not the game)
- [ ] Reviewer: open the page → confirm SFX still play after first click (preload completed via `loadeddata`/`canplay` instead of `canplaythrough`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBNCPHB2pWrDyhQQX6i3db)_