### PR TITLE
Fix: AudioManager preload failed because Audio shadowed window.Audio

### DIFF
--- a/game.js
+++ b/game.js
@@ -254,7 +254,7 @@ const AudioManager = (() => {
             pools[name] = [];
             nextIdx[name] = 0;
             const src = SFX_MANIFEST[name];
-            const probe = new Audio();
+            const probe = new window.Audio();
             probe.preload = 'auto';
             probe.src = src;
             let settled = false;
@@ -264,7 +264,7 @@ const AudioManager = (() => {
                 if (ok) {
                     pools[name].push(probe);
                     for (let i = 1; i < 3; i++) {
-                        const c = new Audio();
+                        const c = new window.Audio();
                         c.preload = 'auto';
                         c.src = src;
                         pools[name].push(c);
@@ -287,7 +287,7 @@ const AudioManager = (() => {
             try { probe.load(); } catch (e) { settle(false); }
         });
         // Music element
-        musicEl = new Audio();
+        musicEl = new window.Audio();
         musicEl.preload = 'auto';
         musicEl.loop = true;
         musicEl.src = MUSIC_PATH;


### PR DESCRIPTION
## Summary

The real cause of the broken audio + stuck loading bar from Step 5: my procedural `const Audio = (() => { ... })()` module from Step 1 **shadowed the browser's global `Audio` constructor (`window.Audio`)**. So `new Audio()` in `AudioManager.preload()` threw `TypeError: Audio is not a constructor`, the SFX preload aborted on the very first sound, the boot bar settle callbacks never fired, no SFX or music were available, and the global `window.onerror` handler I added in PR #10 surfaced exactly this error.

Fix: use `new window.Audio()` explicitly at all three call sites (probe, pool clones, music element). The procedural `Audio` module keeps its name; the global constructor is reached unambiguously.

## Test plan

- [x] `node --check game.js` passes
- [x] All three `new Audio()` sites now use `new window.Audio()`
- [ ] Reviewer: hard-refresh, open DevTools console — confirm the `Audio is not a constructor` error is gone
- [ ] Reviewer: click anywhere on the menu — confirm music starts and SFX play on type / lock / destroy
- [ ] Reviewer: confirm the boot progress bar fills cleanly and disappears within ~4 s
- [ ] Reviewer: confirm the (unrelated) "AudioContext was not allowed to start" warning still appears once on page load — that's the procedural WebAudio Step 1 module being polite about the autoplay rule, it resumes the moment the user clicks anything

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBNCPHB2pWrDyhQQX6i3db)_