### PR TITLE
Menu polish: remove logo image, add rotation/blur/cap to ambient letters

### DIFF
--- a/game.js
+++ b/game.js
@@ -3654,6 +3654,7 @@ function onPlayClicked() {
 // ====================================================================
 const AmbientLetters = (() => {
     const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    const MAX_CONCURRENT = 25;
     let host = null;
     let interval = null;
     let active = false;
@@ -3665,25 +3666,29 @@ const AmbientLetters = (() => {
     }
     function spawn() {
         if (!active || !host) return;
+        // Skip during gameplay to avoid wasted work.
+        if (game.state !== 'menu') return;
+        // Hard cap on concurrent letters keeps the DOM lean even if the tab
+        // is backgrounded then resumed (browsers throttle but never stop rAF).
+        if (host.childElementCount >= MAX_CONCURRENT) return;
         const h = host.clientHeight || window.innerHeight;
         const w = host.clientWidth  || window.innerWidth;
         if (h < 100 || w < 100) return;
-        // Skip during gameplay to avoid wasted work.
-        if (game.state !== 'menu') return;
 
         const letter = document.createElement('span');
         letter.textContent = ALPHABET[Math.floor(Math.random() * ALPHABET.length)];
-        const sz = 14 + Math.random() * 38;
-        const left = Math.random() * 100;
-        const dur = 7 + Math.random() * 8;     // 7–15s fall
-        const alpha = 0.10 + Math.random() * 0.35;
-        // Magenta accent on ~25% of letters for variety
+        const size = 1 + Math.random() * 1.5;          // 1rem → 2.5rem
+        const left = Math.random() * 100;              // viewport columns
+        const dur  = 8 + Math.random() * 7;            // 8–15s fall
+        const alpha = 0.08 + Math.random() * 0.28;     // gentle depth
+        const blur = Math.random() * 2;                // 0–2px parallax blur
+        // Magenta accent on ~25% of letters for palette variety
         const useMagenta = Math.random() < 0.25;
         letter.style.left = left + 'vw';
-        letter.style.fontSize = sz + 'px';
+        letter.style.fontSize = size + 'rem';
+        letter.style.filter = `blur(${blur.toFixed(2)}px)`;
         letter.style.setProperty('--alpha', alpha.toFixed(2));
         letter.style.animation = `amb-fall ${dur}s linear forwards`;
-        letter.style.animationDelay = -(Math.random() * 2) + 's';
         if (useMagenta) {
             letter.style.color = 'var(--neon-magenta)';
             letter.style.textShadow = '0 0 8px var(--neon-magenta)';
@@ -3695,10 +3700,14 @@ const AmbientLetters = (() => {
         ensureHost();
         if (!host || interval) return;
         active = true;
-        // Two letters per second feels alive without being noisy.
-        interval = setInterval(spawn, 500);
-        // Seed a few immediately so it doesn't look empty.
-        for (let i = 0; i < 6; i++) setTimeout(spawn, i * 200);
+        // Ongoing stream — slightly under one per second so blur'd big letters
+        // breathe properly.
+        interval = setInterval(spawn, 1100);
+        // Stagger the initial batch across the first 6 seconds so the screen
+        // doesn't snap from empty → full all at once.
+        for (let i = 0; i < MAX_CONCURRENT; i++) {
+            setTimeout(spawn, Math.random() * 6000);
+        }
     }
     function stop() {
         active = false;

--- a/index.html
+++ b/index.html
@@ -37,7 +37,12 @@
         html, body {
             margin: 0; padding: 0; height: 100%;
             background: var(--bg-deep);
-            background-image: radial-gradient(ellipse at top, var(--bg-mid), var(--bg-deep) 70%);
+            /* Layered radial accents: cyan glow top-left, magenta bottom-right,
+               plus the original ellipse at the top for depth. */
+            background-image:
+                radial-gradient(circle at 10% 20%, rgba(0, 240, 255, 0.07) 0%, transparent 42%),
+                radial-gradient(circle at 90% 80%, rgba(255, 46, 151, 0.06) 0%, transparent 42%),
+                radial-gradient(ellipse at top, var(--bg-mid), var(--bg-deep) 70%);
             color: var(--text-bright);
             font-family: var(--font-ui);
             overflow: hidden;
@@ -929,20 +934,21 @@
         }
         #ambient-letters span {
             position: absolute;
-            top: -40px;
+            top: -5vh;
             font-family: var(--font-game);
             font-weight: 400;
             color: var(--neon-cyan);
             text-shadow: 0 0 8px var(--neon-cyan);
             opacity: 0;
             user-select: none;
-            will-change: transform, opacity;
+            will-change: transform, opacity, filter;
         }
+        /* Falls AND rotates 360° for a more dynamic, organic feel. */
         @keyframes amb-fall {
-            0%   { transform: translateY(-40px); opacity: 0; }
-            10%  { opacity: var(--alpha, 0.5); }
-            90%  { opacity: var(--alpha, 0.5); }
-            100% { transform: translateY(110vh); opacity: 0; }
+            0%   { transform: translateY(-5vh) rotate(0deg); opacity: 0; }
+            10%  { opacity: var(--alpha, 0.4); }
+            90%  { opacity: var(--alpha, 0.4); }
+            100% { transform: translateY(110vh) rotate(360deg); opacity: 0; }
         }
 
         .menu-nav {
@@ -1336,7 +1342,6 @@
 
         <main class="menu-main">
             <section class="hero">
-                <img id="menu-logo" class="title-logo" alt="Word Fall" />
                 <h1 id="menu-title">WORD<span class="accent">FALL</span><span class="live-dot"><span></span></span></h1>
                 <p class="tagline">Where vocabulary meets gravity. Type the falling words before the screen fills.</p>
             </section>


### PR DESCRIPTION
## Summary

Picks up the good ideas from Gemini's styling pass and the dynamic-rain-drop background, kept on the **Neon Keys palette** (cyan + magenta — Gemini's indigo would have clashed with the in-game art). Also removes the menu logo image per request — the text "WORDFALL" is now the brand.

### Adopted from Gemini

| Idea | Adopted as |
|---|---|
| `@keyframes letterFall` rotation 0 → 360deg | `amb-fall` now rotates 0 → 360deg across the fall |
| Per-letter `filter: blur()` | 0–2 px blur per letter for parallax depth |
| `maxLetters = 25` cap via `childElementCount` | Same hard cap — protects perf even when tabs are backgrounded then resumed |
| Staggered initial batch (`setTimeout(spawnLetter, Math.random() * 10000)`) | Initial spawn staggered across the first 6 s so the screen doesn't snap from empty → full |
| Sizing in `rem` | Sizing in `rem` (1 – 2.5) so it scales with the user's root font size |
| Body radial-gradient accents | Two very-low-alpha radials (cyan top-left, magenta bottom-right) layered on top of the existing top-ellipse fade |

### Skipped from Gemini (and why)

| Idea | Why |
|---|---|
| `color: #818cf8` (indigo-400) | Clashes with the Neon Keys palette used everywhere in-game; we keep the cyan + 25 %-magenta accent mix |
| Pure indigo / violet radials on the body | Same reason — adapted to cyan + magenta at low alpha |
| Separate `DOMContentLoaded` script | Already integrated in our `AmbientLetters` module which is state-aware (auto-pauses during gameplay to save CPU); no separate listener needed |

### Logo removal

- Dropped `<img id="menu-logo">` from the menu hero. The text `WORDFALL` with magenta accent on `FALL` plus the pulsing live-dot is the menu brand now.
- `applyLogoAssets()` in `game.js` already short-circuits with `if (!el) return;` so removing the element doesn't throw.
- Game-over screen's small logo image (`go-logo`) is left intact — only the menu was asked about, and the share card / game-over flow still expects it there.

## Test plan

- [x] `node --check game.js` passes
- [ ] Reviewer: hard-refresh, confirm: no image logo on the menu, text "WORDFALL" with magenta "FALL" accent + pulsing dot is the brand
- [ ] Reviewer: confirm ambient letters rotate while falling and have varying blur for depth
- [ ] Reviewer: confirm the menu never accumulates more than ~25 letters even if you leave the tab open
- [ ] Reviewer: confirm the subtle cyan/magenta radial accents are visible at the corners of the body
- [ ] Reviewer: click PLAY and back to menu — ambient letters should pause during gameplay and restart on return

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBNCPHB2pWrDyhQQX6i3db)_