### PR TITLE
Edit #2: legible close buttons + Esc-to-close on all modals

### DIFF
--- a/game.js
+++ b/game.js
@@ -1336,6 +1336,20 @@ function bossEscaped(boss) {
 // ---------- Input ----------
 function onKey(e) {
     if (e.key === 'Escape') {
+        // If any overlay-modal is open, Esc closes the topmost one. We check
+        // the confirm dialog first (deepest), then daily-played, then stats,
+        // then settings. The tutorial deliberately doesn't close on Esc —
+        // it has its own Skip button so first-time players don't dismiss it
+        // by accident.
+        const tryClose = (id) => {
+            const el = document.getElementById(id);
+            if (el && el.classList.contains('show')) { hide(id); return true; }
+            return false;
+        };
+        if (tryClose('confirm-reset') || tryClose('daily-played')
+            || tryClose('stats-modal') || tryClose('settings-modal')) {
+            return;
+        }
         if (game.state === 'playing') {
             game.state = 'paused';
             document.getElementById('pause-hint').classList.add('show');
@@ -3426,6 +3440,10 @@ function wireStep4DOM() {
     document.getElementById('stats-close').addEventListener('click', () => hide('stats-modal'));
     // Daily-played modal
     document.getElementById('dp-close-btn').addEventListener('click', () => hide('daily-played'));
+    const dpX = document.getElementById('dp-close-x');
+    if (dpX) dpX.addEventListener('click', () => hide('daily-played'));
+    const cfX = document.getElementById('confirm-close-x');
+    if (cfX) cfX.addEventListener('click', () => hide('confirm-reset'));
     document.getElementById('dp-share-btn').addEventListener('click', () => {
         const r = getDailyResult();
         if (!r) return;

--- a/index.html
+++ b/index.html
@@ -530,15 +530,61 @@
             box-shadow: 0 0 12px rgba(0, 240, 255, 0.12);
         }
 
+        /* High-contrast circular close button used in Settings, Stats, and
+           any panel that opens over the menu. Sized for fingers, not pixels. */
         .close-x {
-            position: absolute; top: 10px; right: 14px;
-            background: transparent; border: none;
-            color: var(--text-dim);
-            font-size: 28px; line-height: 1;
+            position: absolute;
+            top: 12px;
+            right: 12px;
+            width: 40px;
+            height: 40px;
+            background: rgba(0, 0, 0, 0.55);
+            border: 2px solid var(--neon-cyan);
+            border-radius: 50%;
+            color: var(--text-bright);
+            font-family: var(--font-display);
+            font-size: 26px;
+            line-height: 1;
             cursor: pointer;
-            padding: 4px 8px;
+            padding: 0;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            text-shadow: 0 0 8px var(--neon-cyan);
+            box-shadow: 0 0 12px rgba(0, 240, 255, 0.35), inset 0 0 8px rgba(0, 240, 255, 0.18);
+            transition: transform 0.15s ease, background 0.15s ease,
+                        border-color 0.15s ease, color 0.15s ease,
+                        box-shadow 0.15s ease;
+            z-index: 5;
         }
-        .close-x:hover { color: var(--neon-cyan); }
+        .close-x:hover,
+        .close-x:focus-visible {
+            background: var(--neon-magenta);
+            border-color: var(--neon-magenta);
+            color: #0A0E1A;
+            text-shadow: none;
+            box-shadow: 0 0 18px var(--neon-magenta), inset 0 0 12px rgba(255, 46, 151, 0.45);
+            transform: scale(1.06);
+            outline: none;
+        }
+        .close-x:active { transform: scale(0.96); }
+        @media (max-width: 600px) {
+            .close-x { width: 44px; height: 44px; font-size: 28px; }
+        }
+
+        /* Make in-modal ghost dismiss buttons (Back / Cancel) more legible
+           — they used to read as a faint outline at the bottom of a panel.
+           This brightens borders + text and gives them a clearer hover. */
+        .panel .btn.ghost {
+            border-width: 2px;
+            color: var(--text-bright);
+            text-shadow: 0 0 10px var(--neon-cyan), 0 0 16px var(--neon-cyan);
+        }
+        .panel .btn.ghost:hover {
+            background: rgba(0, 240, 255, 0.10);
+            box-shadow: 0 0 16px rgba(0, 240, 255, 0.55),
+                        inset 0 0 12px rgba(0, 240, 255, 0.18);
+        }
 
         #share-toast {
             position: fixed;
@@ -840,7 +886,26 @@
             border-radius: 16px;
             padding: 28px;
             box-shadow: 0 0 32px rgba(255, 23, 68, 0.25);
+            position: relative;
         }
+        /* On the danger (red) panel, the close X uses a red theme so it
+           reads as part of the same modal language. */
+        #confirm-reset .close-x {
+            border-color: var(--bomb-red);
+            color: var(--text-bright);
+            text-shadow: 0 0 8px var(--bomb-red);
+            box-shadow: 0 0 12px rgba(255, 23, 68, 0.4), inset 0 0 8px rgba(255, 23, 68, 0.18);
+        }
+        #confirm-reset .close-x:hover,
+        #confirm-reset .close-x:focus-visible {
+            background: var(--bomb-red);
+            color: #0A0E1A;
+            text-shadow: none;
+            box-shadow: 0 0 18px var(--bomb-red), inset 0 0 12px rgba(255, 23, 68, 0.5);
+        }
+        /* Daily-played panel needs to be positioned so the close X lands
+           inside it (the default .panel has no position). */
+        .dp-panel { position: relative; }
         .confirm-panel h2 {
             font-family: var(--font-display);
             color: var(--bomb-red);
@@ -1487,7 +1552,8 @@
     </div>
 
     <div class="overlay" id="daily-played">
-        <div class="panel">
+        <div class="panel dp-panel">
+            <button class="close-x" id="dp-close-x" aria-label="Close">&times;</button>
             <h2>DAILY DONE</h2>
             <p id="dp-sub">You crushed today&rsquo;s puzzle.</p>
             <div class="stats">
@@ -1580,6 +1646,7 @@
 
     <div class="overlay" id="confirm-reset">
         <div class="panel confirm-panel">
+            <button class="close-x" id="confirm-close-x" aria-label="Close">&times;</button>
             <h2>RESET?</h2>
             <p>Are you sure? This deletes your high scores, achievements, and daily history. This cannot be undone.</p>
             <div class="btn-row">


### PR DESCRIPTION
Second of the requested edit ideas.

## What was wrong
The `×` in modal corners was painted in `--text-dim` at 28px with no border or background — easy to miss, especially against the cyan-bordered panels. Two of the four modals (Daily-Played, Confirm-Reset) had no corner X at all, only a bottom button.

## Fix
**`.close-x` is now a real button**, not a thin glyph:
- 40×40 (44×44 on viewports ≤600 px → meets WCAG 2.5.5 minimum tap target)
- 2 px cyan ring, bright white glyph, cyan glow + inset glow
- **Hover/focus inverts to magenta** with a 6 % scale-up — unmistakable "this is the close button"
- `:focus-visible` styling so keyboard users get the same treatment
- Confirm-Reset gets a red-themed variant matching its danger panel

**Coverage extended**: added `.close-x` to Daily-Played and Confirm-Reset modals (with `position: relative` on their `.panel` containers so the X lands inside the panel, not the viewport corner). All four modals now have the same dismiss language.

**Ghost dismiss buttons brightened** inside panels — Back / Cancel used to read as faint outlines. Border-width 1 → 2 px, text → `--text-bright` with cyan glow, hover boosts background + box-shadow.

**Esc closes the topmost open modal** before falling through to game pause/resume. Priority: `confirm-reset > daily-played > stats-modal > settings-modal`. Tutorial intentionally exempt (it has its own Skip; we don't want first-time players to dismiss it by accident).

## Files touched
- `index.html`: `.close-x` rules rewritten; ghost-button overrides; corner-X added to two modals; positioning fix on confirm-panel + new dp-panel
- `game.js`: wired the two new X buttons; Esc-closes-topmost added at top of `onKey`

## Test plan
- [x] `node --check game.js` passes
- [x] All six close-related IDs serve in HTML (stats-close, settings-close, dp-close-x, confirm-close-x, dp-close-btn, confirm-cancel)
- [ ] Reviewer: open Settings → confirm X is obvious; click → closes; reopen and press Esc → closes
- [ ] Reviewer: open Stats from menu → X is obvious; tab to it → focus-visible style shows; Enter closes
- [ ] Reviewer: open Daily-Played (after completing a daily) → both X (top-right) and Back (bottom) close it
- [ ] Reviewer: click Reset Lifetime Stats → confirm dialog X is red-themed; Esc closes without resetting
- [ ] Reviewer: during gameplay, press Esc → still pauses (modal-close priority doesn't break pause)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBNCPHB2pWrDyhQQX6i3db)_