### PR TITLE
Boss countdown starts only when the word clears the top cover

### DIFF
--- a/game.js
+++ b/game.js
@@ -1330,7 +1330,9 @@ function spawnBoss() {
         type: 'boss',
         letters, startX,
         // Step-4 difficulty: hard countdown + letter regrowth on stall.
+        // timerArmed flips true only once the word clears the top cover.
         timeLimit, timeLeft: timeLimit,
+        timerArmed: false,
         idleT: 0,
         regrowEnabled: game.level >= 10,
         regrowIdleMs: bossRegrowIdleMs(game.level),
@@ -2049,30 +2051,36 @@ function update(dt) {
     }
 
     // Boss fight: hard countdown + letter regrowth (you can't stall).
-    // Both tick on scaled time, so a FREEZE power-up genuinely helps vs a
-    // boss — it slows the countdown and delays regrowth.
+    // The countdown only ARMS once the boss has fully descended past the top
+    // cover — burning the timer while the word is still hidden/entering isn't
+    // fair. Both tick on scaled time, so a FREEZE power-up genuinely helps.
     if (game.bossState === 'fighting' && game.bossActive) {
         const boss = game.bossActive;
-        boss.timeLeft -= sdt;
-        boss.idleT += sdt;
-        if (boss.regrowEnabled && boss.typed > 0 && boss.typed < boss.text.length
-            && boss.idleT >= boss.regrowIdleMs) {
-            // Idling too long → the most recently shattered letter regrows.
-            const li = boss.letters[boss.typed - 1];
-            if (li) {
-                li.alive = true;
-                li.shatterT = 0;
-                li.regrowT = 280;
-                boss.typed--;
-                boss.idleT = 0;
-                game.flash = Math.max(game.flash, 0.22); game.flashColor = '#FF8A00';
-                game.shake = Math.max(game.shake, 5);
-                renderInput();
-            }
+        if (!boss.timerArmed && boss.y >= TOP_HUD_H + boss.size / 2) {
+            boss.timerArmed = true;
         }
-        if (boss.timeLeft <= 0) {
-            bossEscaped(boss);
-            return;
+        if (boss.timerArmed) {
+            boss.timeLeft -= sdt;
+            boss.idleT += sdt;
+            if (boss.regrowEnabled && boss.typed > 0 && boss.typed < boss.text.length
+                && boss.idleT >= boss.regrowIdleMs) {
+                // Idling too long → the most recently shattered letter regrows.
+                const li = boss.letters[boss.typed - 1];
+                if (li) {
+                    li.alive = true;
+                    li.shatterT = 0;
+                    li.regrowT = 280;
+                    boss.typed--;
+                    boss.idleT = 0;
+                    game.flash = Math.max(game.flash, 0.22); game.flashColor = '#FF8A00';
+                    game.shake = Math.max(game.shake, 5);
+                    renderInput();
+                }
+            }
+            if (boss.timeLeft <= 0) {
+                bossEscaped(boss);
+                return;
+            }
         }
     }
 


### PR DESCRIPTION
## Problem
The boss spawns at `y = -100` and descends in from above the top HUD strip, but its countdown started decrementing the instant `spawnBoss()` ran. So a few seconds of the budget burned while the word was still hidden / entering behind the top cover — exactly the unfair feel you flagged.

## Fix
Added `boss.timerArmed` (false at spawn). The countdown — and the idle/regrowth clock with it — now only ticks once the boss has **fully cleared the top cover**:

```
boss.y >= TOP_HUD_H + boss.size / 2
```

i.e. the word's top edge is below the 60px HUD strip and the whole word is on screen. Until armed, the HUD simply shows the full budget (`timeLeft` stays at `timeLimit`) as a natural "get ready" state — no HUD change needed.

The separate floor-crash escape path is untouched.

## Test plan
- [x] `node --check game.js` passes
- [x] `timerArmed` wired at 3 sites: init (`false`), arm-check, gated tick
- [ ] Reviewer: reach a boss — confirm the countdown bar/seconds hold at full while the word descends, and only start draining the moment it clears the top cover and is fully visible
- [ ] Reviewer: confirm regrowth (L10+) also doesn't kick in until the word is visible

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBNCPHB2pWrDyhQQX6i3db)_