### PR TITLE
Decoys are typeable traps now (0-point combo-break + bomb power-up scoring fix)

### DIFF
--- a/game.js
+++ b/game.js
@@ -1516,12 +1516,18 @@ function onKey(e) {
 
     if (!game.target) {
         const candidates = lockOnCandidates();
-        let best = null;
+        // Prefer the lowest non-decoy match; only fall back to a decoy if no
+        // real word starts with this letter.
+        let best = null, bestDecoy = null;
         for (const w of candidates) {
-            if (w.text[0] === ch) {
+            if (w.text[0] !== ch) continue;
+            if (w.type === 'decoy') {
+                if (!bestDecoy || w.y > bestDecoy.y) bestDecoy = w;
+            } else {
                 if (!best || w.y > best.y) best = w;
             }
         }
+        if (!best) best = bestDecoy;
         if (best) {
             game.target = best;
             best.typed = 1;
@@ -1589,7 +1595,10 @@ function lockOnCandidates() {
         return [game.bossActive];
     }
     if (game.bossState === 'warning') return [];
-    return game.words.filter(w => w.type !== 'decoy' && w.type !== 'boss');
+    // Decoys ARE lockable now (0-point combo-trap on completion). Lock-on
+    // still PREFERS non-decoy candidates so they only catch sloppy typing —
+    // see the picker in onKey.
+    return game.words.filter(w => w.type !== 'boss');
 }
 
 function letterScreenX(boss, letter) {
@@ -1628,6 +1637,21 @@ function typeMultiplier(t) {
 }
 
 function completeWord(w) {
+    // Decoy: you typed a fake. 0 points, combo break, clear feedback so the
+    // player learns the warning. No life loss — the visual strikethrough +
+    // ghost-cyan glow was the warning.
+    if (w.type === 'decoy') {
+        game.combo = 0;
+        game.multiplier = 1;
+        game.comboTimer = 0;
+        showToast('BAIT', '#FF8A00');
+        game.flash = Math.max(game.flash, 0.35); game.flashColor = '#FF8A00';
+        game.shake = Math.max(game.shake, 6);
+        explodeAt(w.x, w.y, false, 12, 'cyan');
+        game.words = game.words.filter(x => x !== w);
+        game.target = null; game.input = ''; renderInput();
+        return;
+    }
     const base = 10 * w.text.length;
     const typeMul = typeMultiplier(w.type);
     let gained = Math.round(base * typeMul * game.multiplier);
@@ -1826,10 +1850,15 @@ function usePowerup(kind) {
         game.flash = 0.3; game.flashColor = '#00F0FF';
     } else if (kind === 'bomb') {
         const targets = game.words.filter(w => w.type !== 'boss');
-        const reward = targets.length;
+        // Only real words contribute to the score + the toast count;
+        // decoys are vapourised for free.
+        let reward = 0;
         for (const w of targets) {
             explodeAt(w.x, w.y, false, 22, 'cyan');
-            game.score += Math.round(5 * w.text.length * game.multiplier);
+            if (w.type !== 'decoy') {
+                reward++;
+                game.score += Math.round(5 * w.text.length * game.multiplier);
+            }
         }
         game.words = game.words.filter(w => w.type === 'boss');
         // If the bomb-power-up killed a twin's partner, clean other twin's chain state.
@@ -2482,17 +2511,31 @@ function drawWords(ctx) {
         ctx.font = `${fontSize}px VT323, monospace`;
 
         if (w.type === 'decoy') {
-            // Was almost invisible — bump the pulse range, give it a soft
-            // ghost-cyan glow + a strikethrough so it's obviously a 'fake'
-            // word but still readable.
-            const alpha = 0.55 + 0.30 * (0.5 + 0.5 * Math.sin(t / 1500 * 2 * Math.PI));
+            // Ghost-cyan + strikethrough = "do not type". If the player ignores
+            // the warning and locks one, the typed prefix renders in WARNING
+            // ORANGE (not gold like real words) so it reads as wrong-doing,
+            // and a 'BAIT' toast fires on completion.
+            const alpha = isTarget
+                ? 0.95                                  // pin to full when locked, no pulse
+                : 0.55 + 0.30 * (0.5 + 0.5 * Math.sin(t / 1500 * 2 * Math.PI));
             ctx.globalAlpha = alpha;
-            drawWordSegment(ctx, w.text, x, y, '#9fb0d8', '#9fb0d8', 10, /*centered*/true);
-            // Strikethrough hint (also doubles as a clear "do not type" cue).
-            // Reuses the spawn-time width on the word object — no per-frame
-            // measureText.
-            ctx.strokeStyle = 'rgba(159, 176, 216, 0.7)';
-            ctx.lineWidth = 1.5;
+            if (isTarget && w.typed > 0) {
+                const totalW = w.width;
+                const startX = x - totalW / 2;
+                ctx.textAlign = 'left';
+                const typed = w.text.slice(0, w.typed);
+                const rest  = w.text.slice(w.typed);
+                const typedW = ctx.measureText(typed).width;
+                drawWordSegment(ctx, typed, startX, y, '#FF8A00', '#FF8A00', 14, false);
+                drawWordSegment(ctx, rest,  startX + typedW, y, '#9fb0d8', '#9fb0d8', 10, false);
+                ctx.textAlign = 'center';
+            } else {
+                drawWordSegment(ctx, w.text, x, y, '#9fb0d8', '#9fb0d8', 10, /*centered*/true);
+            }
+            // Strikethrough hint. Reuses the spawn-time width on the word —
+            // no per-frame measureText for layout.
+            ctx.strokeStyle = isTarget ? 'rgba(255, 138, 0, 0.85)' : 'rgba(159, 176, 216, 0.7)';
+            ctx.lineWidth = isTarget ? 2 : 1.5;
             ctx.beginPath();
             ctx.moveTo(x - w.width / 2, y);
             ctx.lineTo(x + w.width / 2, y);


### PR DESCRIPTION
## What you flagged
"The opaque words don't get affected with the typing" — decoys ignored every keystroke, so attempting to type one produced zero response. Originally a deliberate design ("pure visual clutter"), but in practice it read as broken.

## Fix: decoys become typeable **traps**
- **Lockable now.** `lockOnCandidates` no longer filters them out. Lock-on picker still **prefers the lowest non-decoy match**; a decoy only locks if no real word shares the letter. Careful typing skips them; sloppy typing trips the trap.
- **Completing a decoy** is a 0-point combo-break:
  - `completeWord` early-returns for `'decoy'` — score: 0, combo → 0, multiplier → 1
  - `BAIT` toast, orange screen flash, small shake, light cyan fizzle
  - **No life loss** — the strikethrough was the warning
- **Visual feedback while locked.** The decoy renders with its typed prefix in **warning orange** (not gold like real words) — the player sees they're doing the wrong thing the moment the first letter highlights. Ambient ghost-cyan pulse pins to 95% alpha while locked; strikethrough re-tints to orange and thickens.

## Bonus: bomb power-up bug found while in there
`usePowerup('bomb')` was awarding `5 × length × multiplier` **per decoy** and counting decoys in the `BOMB xN` toast. Now decoys are vapourised for free — no score contribution, not counted in the multiplier.

## What's preserved
- Floor-crash on a decoy: still no penalty (visual was the warning).
- Touch tap-to-lock keeps its decoy filter — taps are explicit pointing actions, not recognition mistakes, so mis-aim shouldn't punish.
- Decoy spawn weights, fall speed, and ambient strikethrough warning all unchanged.

## Test plan
- [x] `node --check game.js` passes
- [x] No remaining `decoy` lock-on filter in the keyboard path; touch path still filters them
- [ ] Reviewer: type the first letter of an opaque/strikethrough word — it locks with **orange** typed letters (not gold) so you know it's a trap; finish it → 0 points, combo resets, `BAIT` toast
- [ ] Reviewer: type the first letter of a real word that shares a letter with a decoy → the real word is preferred for lock-on
- [ ] Reviewer: detonate a `bomb` power-up with mixed words on screen → the score bump and `BOMB xN` only counts real words
- [ ] Reviewer: ignore a decoy and let it crash → still no life lost / no penalty

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBNCPHB2pWrDyhQQX6i3db)_