### PR TITLE
Fix external-refactor breakage: syntax errors, TDZ crashes, and SW cache trap

### DIFF
--- a/game.js
+++ b/game.js
@@ -14,6 +14,36 @@ window.addEventListener('unhandledrejection', (e) => {
     console.error('Word Fall unhandled rejection:', e.reason);
 });
 
+// ---------- localStorage key constants ----------
+// Declared FIRST: the DeepSeek module below reads LS_DEEPSEEK_KEY at
+// module-eval time, so these must precede every IIFE in this file
+// (a later declaration left it in the temporal dead zone and crashed
+// the whole script at startup).
+const LS_HIGH_SCORES        = 'wordfall.high';
+const LS_LIFETIME_STATS     = 'wordfall_lifetime_stats';
+const LS_ACHIEVEMENTS       = 'wordfall_achievements';
+const LS_SETTINGS           = 'wordfall_settings';
+const LS_TUTORIAL_DONE      = 'wordfall_tutorial_completed';
+const LS_DAILY_PREFIX       = 'wordfall_daily_';
+const LS_DEEPSEEK_KEY       = 'wordfall_deepseek_key';
+
+// ---------- Named constants (extracted from magic numbers) ----------
+// Also declared first — the game state object and several IIFEs read
+// these at module-eval time.
+const COMBO_TIMEOUT_MS      = 3200;   // ms before combo resets
+const BULLET_TRAVEL_MS      = 140;    // bullet flight duration
+const BOSS_REGROW_IDLE_MS   = 280;    // boss letter idle → regrow threshold (overridden per boss)
+const FLASH_DECAY_RATE      = 0.003;  // per-ms flash alpha decay
+const SHAKE_DECAY_RATE      = 0.05;   // per-ms shake decay
+const HEART_FX_DURATION_MS  = 400;    // heart-loss animation length
+const TOAST_DURATION_MS     = 1800;   // toast display time
+const FIRE_ANIM_MS          = 100;    // cannon fire animation duration
+const DEFAULT_SPAWN_MS      = 1800;   // base spawn interval
+const WORDS_PER_LEVEL       = 12;     // words to clear per level
+const MAX_MULTIPLIER        = 6.0;    // combo multiplier cap
+const COMBO_PER_POWERUP     = 10;     // combo count that grants a power-up
+const PARTICLE_GRAVITY      = 0.0002; // per-ms² downward acceleration for particles
+
 // ╔══════════════════════════════════════════════════════════════╗
 // ║  MODULE: Data — Word lists, boss vocabulary, achievements  ║
 // ╚══════════════════════════════════════════════════════════════╝
@@ -1197,30 +1227,6 @@ function recentWordTexts() { return new Set(game.words.map(w => w.text)); }
 // net in case the data ever drifts or DeepSeek hallucinates a boss word.
 const BOSS_WORDS_SET = new Set(BOSS_WORDS);
 
-// ---------- Named constants (extracted from magic numbers) ----------
-const COMBO_TIMEOUT_MS      = 3200;   // ms before combo resets
-const BULLET_TRAVEL_MS      = 140;    // bullet flight duration
-const BOSS_REGROW_IDLE_MS   = 280;    // boss letter idle → regrow threshold (overridden per boss)
-const FLASH_DECAY_RATE      = 0.003;  // per-ms flash alpha decay
-const SHAKE_DECAY_RATE      = 0.05;   // per-ms shake decay
-const HEART_FX_DURATION_MS  = 400;    // heart-loss animation length
-const TOAST_DURATION_MS     = 1800;   // toast display time
-const FIRE_ANIM_MS          = 100;    // cannon fire animation duration
-const DEFAULT_SPAWN_MS      = 1800;   // base spawn interval
-const WORDS_PER_LEVEL       = 10;     // words to clear per level
-const MAX_MULTIPLIER        = 6.0;    // combo multiplier cap
-const COMBO_PER_POWERUP     = 10;     // combo count that grants a power-up
-const PARTICLE_GRAVITY      = 0.0002; // per-ms² downward acceleration for particles
-
-// ---------- localStorage key constants ----------
-const LS_HIGH_SCORES        = 'wordfall.high';
-const LS_LIFETIME_STATS     = 'wordfall_lifetime_stats';
-const LS_ACHIEVEMENTS       = 'wordfall_achievements';
-const LS_SETTINGS           = 'wordfall_settings';
-const LS_TUTORIAL_DONE      = 'wordfall_tutorial_completed';
-const LS_DAILY_PREFIX       = 'wordfall_daily_';
-const LS_DEEPSEEK_KEY       = 'wordfall_deepseek_key';
-
 // localPool is pure of game.level — cache the filtered array per level so
 // pickWord (called once per spawn) doesn't re-allocate on every word.
 const _localPoolCache = Object.create(null);
@@ -1598,7 +1604,7 @@ function bossEscaped(boss) {
     game.combo = 0; game.multiplier = 1; game.comboTimer = 0;
     const lossCount = Math.min(2, game.lives);
     for (let i = 0; i < lossCount; i++) {
-        game.heartFx.push({ idx: game.lives - 1 - i, life: 500 }  // Versus uses longer heart anim);
+        game.heartFx.push({ idx: game.lives - 1 - i, life: 500 }); // Versus uses longer heart anim
     }
     game.lives -= 2;
     game.shake = Math.max(game.shake, 28);
@@ -1920,7 +1926,7 @@ function comboMilestoneCheck() {
 }
 
 function levelUpCheck() {
-    const targetLevel = 1 + Math.floor(game.wordsCompleted / 12);
+    const targetLevel = 1 + Math.floor(game.wordsCompleted / WORDS_PER_LEVEL);
     if (targetLevel > game.level) {
         game.level = targetLevel;
         Audio.levelUp();
@@ -4909,7 +4915,7 @@ const Versus = (() => {
         }
         for (let i = 0; i < damage && defender.lives > 0; i++) {
             defender.lives--;
-            defender.heartFx.push({ idx: defender.lives, life: 500 }  // Versus uses longer heart anim);
+            defender.heartFx.push({ idx: defender.lives, life: 500 }); // Versus uses longer heart anim
         }
         defender.combo = 0; defender.multiplier = 1; defender.comboTimer = 0;
         state.shake = Math.max(state.shake, defender.which === 'you' ? 16 : 12);

--- a/index.html
+++ b/index.html
@@ -331,9 +331,11 @@
 
     <script src="game.js"></script>
     <script>
-        // Register service worker for offline / PWA support
+        // Register service worker for offline / PWA support.
+        // Relative path so it works at a domain root AND under a project
+        // path like /wordfall/ on GitHub Pages (absolute '/sw.js' 404s there).
         if ('serviceWorker' in navigator) {
-            navigator.serviceWorker.register('/sw.js').catch(() => {});
+            navigator.serviceWorker.register('./sw.js').catch(() => {});
         }
     </script>
 </body>

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Word Fall",
   "short_name": "WordFall",
   "description": "Arcade typing game — words rain down, type to blast them away!",
-  "start_url": "/",
+  "start_url": "./",
   "display": "standalone",
   "orientation": "portrait",
   "background_color": "#0A0E1A",

--- a/sw.js
+++ b/sw.js
@@ -1,51 +1,73 @@
 /* Word Fall — Service Worker
    Enables offline play and home-screen installation (PWA).
-   Strategy: cache-first for static assets, network-first for API calls. */
 
-const CACHE_NAME = 'wordfall-v1';
+   Strategy:
+   - CODE (html / css / js / manifest): NETWORK-FIRST with cache fallback.
+     Code must always update when online — a cache-first policy here once
+     pinned a broken build onto every visitor with no way to recover.
+   - ASSETS (images / audio / fonts): cache-first with network fill.
+     Heavy and effectively immutable; instant loads + offline support.
+   - API calls (DeepSeek): network only, never cached.
 
-const STATIC_ASSETS = [
-  '/',
-  '/index.html',
-  '/styles.css',
-  '/game.js',
-  '/manifest.json',
-  '/assets/img/bg-skyline.png',
-  '/assets/img/cannon-typewriter.png',
-  '/assets/img/logo-wordmark.png',
-  '/assets/img/boss-warning.png',
-  '/assets/img/share-card-bg.png',
-  '/assets/img/key-base.png',
-  '/assets/icons/icon-freeze.png',
-  '/assets/icons/icon-bomb.png',
-  '/assets/icons/icon-shield.png',
-  '/assets/icons/icon-settings.png',
-  '/assets/vfx/shard-neon.png',
-  '/assets/vfx/spark-cyan.png',
-  '/assets/vfx/spark-magenta.png',
-  '/assets/vfx/chain-link.png',
-  '/assets/audio/music-main-loop.mp3',
-  '/assets/audio/music-menu-loop.wav',
-  '/assets/audio/sfx-bomb.mp3',
-  '/assets/audio/sfx-boss-defeat.mp3',
-  '/assets/audio/sfx-boss-warning.mp3',
-  '/assets/audio/sfx-combo.mp3',
-  '/assets/audio/sfx-destroy.mp3',
-  '/assets/audio/sfx-lock.mp3',
-  '/assets/audio/sfx-powerup.mp3',
-  '/assets/audio/sfx-type.wav',
+   All paths are RELATIVE so the worker functions both at a domain root
+   and under a project path like /wordfall/ on GitHub Pages. */
+
+const CACHE_NAME = 'wordfall-v2'; // bump to purge clients' old caches
+
+const PRECACHE_ASSETS = [
+  './',
+  './index.html',
+  './styles.css',
+  './game.js',
+  './manifest.json',
+  './assets/img/bg-skyline.png',
+  './assets/img/cannon-typewriter.png',
+  './assets/img/logo-wordmark.png',
+  './assets/img/boss-warning.png',
+  './assets/img/share-card-bg.png',
+  './assets/img/key-base.png',
+  './assets/icons/icon-freeze.png',
+  './assets/icons/icon-bomb.png',
+  './assets/icons/icon-shield.png',
+  './assets/icons/icon-settings.png',
+  './assets/icons/icon-192.png',
+  './assets/icons/icon-512.png',
+  './assets/vfx/shard-neon.png',
+  './assets/vfx/spark-cyan.png',
+  './assets/vfx/spark-magenta.png',
+  './assets/vfx/chain-link.png',
+  './assets/audio/music-main-loop.mp3',
+  './assets/audio/music-menu-loop.wav',
+  './assets/audio/sfx-bomb.mp3',
+  './assets/audio/sfx-boss-defeat.mp3',
+  './assets/audio/sfx-boss-warning.mp3',
+  './assets/audio/sfx-combo.mp3',
+  './assets/audio/sfx-destroy.mp3',
+  './assets/audio/sfx-lock.mp3',
+  './assets/audio/sfx-powerup.mp3',
+  './assets/audio/sfx-type.wav',
 ];
 
-// Install: pre-cache all static assets
+// Paths treated as code → network-first. Everything else is an asset.
+function isCodeRequest(url) {
+  const p = url.pathname;
+  return p.endsWith('/') || p.endsWith('.html') || p.endsWith('.css')
+      || p.endsWith('.js') || p.endsWith('.json');
+}
+
+// Install: best-effort pre-cache. cache.addAll() rejects the whole install
+// if a single asset 404s; caching individually keeps installation robust.
 self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME)
-      .then(cache => cache.addAll(STATIC_ASSETS))
+      .then(cache => Promise.allSettled(
+        PRECACHE_ASSETS.map(a => cache.add(a))
+      ))
       .then(() => self.skipWaiting())
   );
 });
 
-// Activate: clean up old caches
+// Activate: clean up old caches (this is what purges a stale broken build).
 self.addEventListener('activate', (event) => {
   event.waitUntil(
     caches.keys()
@@ -56,37 +78,36 @@ self.addEventListener('activate', (event) => {
   );
 });
 
-// Fetch: cache-first for static, network-first for API
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
 
-  // DeepSeek API calls — always go to network, never cache
+  // API calls — always network, never cached.
   if (url.hostname.includes('deepseek') || url.hostname.includes('api.')) {
-    event.respondWith(fetch(event.request));
-    return;
+    return; // default browser fetch
   }
 
-  // Google Fonts — cache with network fallback
-  if (url.hostname.includes('fonts.googleapis.com') || url.hostname.includes('fonts.gstatic.com')) {
+  // CODE — network-first so updates always flow; cached copy only when offline.
+  if (url.origin === self.location.origin && isCodeRequest(url)) {
     event.respondWith(
-      caches.match(event.request).then(cached => {
-        const fetched = fetch(event.request).then(response => {
-          const clone = response.clone();
-          caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+      fetch(event.request)
+        .then(response => {
+          if (response && response.status === 200) {
+            const clone = response.clone();
+            caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+          }
           return response;
-        });
-        return cached || fetched;
-      })
+        })
+        .catch(() => caches.match(event.request))
     );
     return;
   }
 
-  // Everything else — cache first, then network
+  // ASSETS (same-origin media + cross-origin fonts) — cache-first.
   event.respondWith(
     caches.match(event.request).then(cached => {
-      return cached || fetch(event.request).then(response => {
-        // Cache successful responses for future offline use
-        if (response.status === 200) {
+      if (cached) return cached;
+      return fetch(event.request).then(response => {
+        if (response && response.status === 200) {
           const clone = response.clone();
           caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
         }


### PR DESCRIPTION
## The report
After the external refactor (PR #27), **nothing worked** — mouse couldn't start the game, menus and options dead.

## Root causes (four found, all fixed)

### 1. Syntax errors ×2 — the actual "nothing responds"
The refactor inserted comments *inside* function-call argument lists, swallowing the closing paren:
```js
game.heartFx.push({ idx: ..., life: 500 }  // Versus uses longer heart anim);
```
in `bossEscaped()` and `Versus.landHit()`. The **entire script failed to parse**, so no event handler was ever attached. That alone explains every symptom.

### 2. TDZ ReferenceErrors ×2 — would have kept it dead anyway
The refactor extracted `LS_*` localStorage keys + gameplay constants into blocks at ~line 1200, but they're read **at module-eval time**:
- `LS_DEEPSEEK_KEY` read at line 66 (DeepSeek IIFE initializer)
- `DEFAULT_SPAWN_MS` read at line 814 (the `game` state object)

`const` is hoisted but dead until its declaration line → `ReferenceError` at startup → script aborts. Both constant blocks moved to the top of the file, above every IIFE. **Verified with a Node DOM-shim smoke run that evaluates the entire script end-to-end** (much stronger than `node --check`; this is what caught bug #2 after #1 was fixed).

### 3. Service-worker cache trap — why fixes wouldn't reach anyone
`sw.js` served `game.js` **cache-first with no revalidation**. Every visitor who loaded the broken build had it pinned in `wordfall-v1` forever — pushing a fix changed nothing for them. Also all SW paths were absolute (`/game.js`), which 404s on GitHub Pages project sites (`/wordfall/`).

Rewrote `sw.js`:
- `CACHE_NAME` bumped → `wordfall-v2` (activation purges every client's stale cache)
- **Network-first for code** (html/css/js/json) with cache fallback offline; cache-first kept for heavy media
- All paths relative (`./game.js`); `register('./sw.js')`; manifest `start_url: "./"`
- Install caches per-asset via `Promise.allSettled` — one missing file can't fail the whole install

### 4. Constant drift
`WORDS_PER_LEVEL` was extracted as `10` but the live level-up logic still divides by `12`. Set the constant to 12 (actual behavior) and wired it into `levelUpCheck` so they can't diverge.

## Verification
- [x] `node --check` passes on game.js + sw.js
- [x] Full-script DOM-shim smoke run: evaluates without throwing
- [x] All 67 `getElementById` targets exist in index.html
- [x] All files serve 200 from dev server
- [ ] Reviewer: hard-refresh (Ctrl-Shift-R), confirm menu clicks / Play / Settings / tier picker all respond
- [ ] Reviewer: if it still looks broken once, that's the old SW serving stale cache — reload once more (the v2 worker purges it), or DevTools → Application → Service Workers → Unregister

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBNCPHB2pWrDyhQQX6i3db)_